### PR TITLE
Improve persistent data api

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,5 +24,6 @@ Gameplay rounds are controlled through AirConsole's setActivePlayers API.
 - Added :gift_heart:: New function `setImmersiveState` to control immersive emotions in environments that support this technical capability 
 
 ### Changed
-- storePersistentData's uid parameter is no longer optional.
-- requestPersistentData's uids parameter is no longer optional.
+
+- storePersistentData's uid parameter is no longer optional for screens.
+- requestPersistentData's uids parameter is no longer optional for screens.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,3 +22,7 @@ Gameplay rounds are controlled through AirConsole's setActivePlayers API.
 - Added :gift_heart:: `silence_inactive_players` to AirConsole Opts, which when set will silence new players while
   setActivePlayers is in a state with 1 or more players.
 - Added :gift_heart:: New function `setImmersiveState` to control immersive emotions in environments that support this technical capability 
+
+### Changed
+- storePersistentData's uid parameter is no longer optional.
+- requestPersistentData's uids parameter is no longer optional.

--- a/airconsole-1.9.0-beta.js
+++ b/airconsole-1.9.0-beta.js
@@ -828,13 +828,18 @@ AirConsole.prototype.setOrientation = function(orientation) {
 /**
  * Requests persistent data from the servers.
  * @param {Array<String>} uids - The uids for which you would like to request the persistent data.
- * @version 1.9.0 - uids is no longer optional
+ * @version 1.9.0 - uids is no longer optional for requests from the screen
  */
-AirConsole.prototype.requestPersistentData = function(uids) {
-  if (!uids) {
-    throw new Error("A valid array of uids must be provided");
-  } else if (uids.length < 1) {
-    throw new Error("At least one valid uid must be provided");
+AirConsole.prototype.requestPersistentData = function (uids) {
+  if (this.device_id === AirConsole.SCREEN) {
+    if (!uids) {
+      throw new Error("A valid array of uids must be provided on the screen");
+    } else if (uids.length < 1) {
+      throw new Error("At least one valid uid must be provided on the screen");
+    }
+  } else {
+    uids = uids || [];
+    uids.push(this.getUID());
   }
   this.set_("persistentrequest", { uids: uids });
 };
@@ -854,13 +859,17 @@ AirConsole.prototype.onPersistentDataLoaded = function(data) {};
  * @param {String} key - The key of the data entry.
  * @param {mixed} value - The value of the data entry.
  * @param {String} uid - The uid for which the data should be stored.
- * @version 1.9.0 - uid is no longer optional
+ * @version 1.9.0 - uid is no longer optional for requests from the screen
  */
-AirConsole.prototype.storePersistentData = function(key, value, uid) {
-  if (!uid) {
-    throw new Error("A valid uid must be provided");
+AirConsole.prototype.storePersistentData = function (key, value, uid) {
+  if (this.device_id === AirConsole.SCREEN) {
+    if (!uid) {
+      throw new Error("A valid uid must be provided on the screen");
+    }
+  } else {
+    uid = this.getUID();
   }
-  this.set_("persistentstore", {"key": key, "value": value, "uid": uid});
+  this.set_("persistentstore", { key: key, value: value, uid: uid });
 };
 
 /**

--- a/airconsole-1.9.0-beta.js
+++ b/airconsole-1.9.0-beta.js
@@ -833,10 +833,10 @@ AirConsole.prototype.setOrientation = function(orientation) {
 AirConsole.prototype.requestPersistentData = function(uids) {
   if (!uids) {
     throw new Error("A valid array of uids must be provided");
-  } else if(uids.length < 1){
+  } else if (uids.length < 1) {
     throw new Error("At least one valid uid must be provided");
   }
-  this.set_("persistentrequest", {"uids": uids})
+  this.set_("persistentrequest", { uids: uids });
 };
 
 /**

--- a/airconsole-1.9.0-beta.js
+++ b/airconsole-1.9.0-beta.js
@@ -828,6 +828,8 @@ AirConsole.prototype.setOrientation = function(orientation) {
 /**
  * Requests persistent data from the servers.
  * @param {Array<String>} uids - The uids for which you would like to request the persistent data.
+ *                                         For controllers, the default is the uid of this device.
+ *                                         Screens must provide a valid array of uids.
  * @version 1.9.0 - uids is no longer optional for requests from the screen
  */
 AirConsole.prototype.requestPersistentData = function (uids) {
@@ -859,6 +861,8 @@ AirConsole.prototype.onPersistentDataLoaded = function(data) {};
  * @param {String} key - The key of the data entry.
  * @param {mixed} value - The value of the data entry.
  * @param {String} uid - The uid for which the data should be stored.
+ *                       For controllers, the default is the uid of this device.
+ *                       Screens must provide a valid uid.
  * @version 1.9.0 - uid is no longer optional for requests from the screen
  */
 AirConsole.prototype.storePersistentData = function (key, value, uid) {

--- a/airconsole-1.9.0-beta.js
+++ b/airconsole-1.9.0-beta.js
@@ -827,13 +827,14 @@ AirConsole.prototype.setOrientation = function(orientation) {
 
 /**
  * Requests persistent data from the servers.
- * @param {Array<String>|undefined} uids - The uids for which you would like
- *                                         to request the persistent data.
- *                                         Default is the uid of this device.
+ * @param {Array<String>} uids - The uids for which you would like to request the persistent data.
+ * @version 1.9.0 - uids is no longer optional
  */
 AirConsole.prototype.requestPersistentData = function(uids) {
   if (!uids) {
-    uids = [this.getUID()];
+    throw new Error("A valid array of uids must be provided");
+  } else if(uids.length < 1){
+    throw new Error("At least one valid uid must be provided");
   }
   this.set_("persistentrequest", {"uids": uids})
 };
@@ -852,12 +853,12 @@ AirConsole.prototype.onPersistentDataLoaded = function(data) {};
  * Do not store sensitive data.
  * @param {String} key - The key of the data entry.
  * @param {mixed} value - The value of the data entry.
- * @param {String|undefiend} uid - The uid for which the data should be stored.
- *                                 Default is the uid of this device.
+ * @param {String} uid - The uid for which the data should be stored.
+ * @version 1.9.0 - uid is no longer optional
  */
 AirConsole.prototype.storePersistentData = function(key, value, uid) {
   if (!uid) {
-    uid = this.getUID();
+    throw new Error("A valid uid must be provided");
   }
   this.set_("persistentstore", {"key": key, "value": value, "uid": uid});
 };

--- a/tests/spec/methods/spec-persistent-data.js
+++ b/tests/spec/methods/spec-persistent-data.js
@@ -3,7 +3,9 @@ function testPersistentData() {
     var uids = [1, 3];
     var expected_data = { action: "set", key: "persistentrequest", value: { uids: uids } };
     spyOn(AirConsole, 'postMessage_');
+
     airconsole.requestPersistentData(uids);
+
     expect(AirConsole.postMessage_).toHaveBeenCalledWith(expected_data);
   });
 
@@ -11,34 +13,74 @@ function testPersistentData() {
     var value = { key: "hero", value: 2, uid: 293 };
     var expected_data = { action: "set", key: "persistentstore", value: value };
     spyOn(AirConsole, 'postMessage_');
+
     airconsole.storePersistentData("hero", 2, 293);
+
     expect(AirConsole.postMessage_).toHaveBeenCalledWith(expected_data);
   });
 
-  it ("Should throw an error when storing persistent data without a uid", function() {
+  it ("Should throw an error when storing persistent data without a uid from screen", function() {
+    airconsole.device_id = 0;
     var value = { key: "hero", value: 2, uid: 293 };
     var expected_data = { action: "set", key: "persistentstore", value: value };
 
     try {
       airconsole.storePersistentData("hero", 2);
     } catch (e){
-      expect(e).toEqual(new Error("A valid uid must be provided"));
+      expect(e).toEqual(new Error("A valid uid must be provided on the screen"));
     }
   });
 
-  it ("Should throw an error when requesting persistent data without uids", function() {
+  it ("Should throw an error when storing persistent data without a uid from controller", function() {
+    airconsole.device_id = 1;
+    expected_uid = 123;
+    airconsole.devices[1] = { uid: expected_uid }
+    spyOn(AirConsole, 'postMessage_');
+
+    airconsole.storePersistentData("hero", 2);
+
+    expect(AirConsole.postMessage_).toHaveBeenCalledWith({ action: 'set', key: 'persistentstore', value: { key: 'hero', value: 2, uid: expected_uid}});
+  });
+
+  it ("Should throw an error when requesting persistent data without uids from screen", function() {
+    airconsole.device_id = 0;
+
     try {
       airconsole.requestPersistentData();
     } catch (e){
-      expect(e).toEqual(new Error("A valid array of uids must be provided"));
+      expect(e).toEqual(new Error("A valid array of uids must be provided on the screen"));
     }
   });
 
-  it ("Should throw an error when requesting persistent data with an empty uids array", function() {
+  it ("Should complete the uid when requesting persistent data without uids from controller", function() {
+    airconsole.device_id = 1;
+    expected_uid = 123;
+    airconsole.devices[1] = { uid: expected_uid }
+    spyOn(AirConsole, 'postMessage_');
+
+    airconsole.requestPersistentData();
+
+    expect(AirConsole.postMessage_).toHaveBeenCalledWith({ action: 'set', key: 'persistentrequest', value: { uids: [expected_uid]}});
+  });
+
+  it ("Should complete the uid when requesting persistent data with empty uids from controller", function() {
+    airconsole.device_id = 1;
+    expected_uid = 123;
+    airconsole.devices[1] = { uid: expected_uid }
+    spyOn(AirConsole, 'postMessage_');
+
+    airconsole.requestPersistentData([]);
+
+    expect(AirConsole.postMessage_).toHaveBeenCalledWith({ action: 'set', key: 'persistentrequest', value: { uids: [expected_uid]}});
+  });
+
+  it ("Should throw an error when requesting persistent data with an empty uids array from screen", function() {
+    airconsole.device_id = 0;
+
     try {
       airconsole.requestPersistentData([]);
     } catch (e){
-      expect(e).toEqual(new Error("At least one valid uid must be provided"));
+      expect(e).toEqual(new Error("At least one valid uid must be provided on the screen"));
     }
   });
 }

--- a/tests/spec/methods/spec-persistent-data.js
+++ b/tests/spec/methods/spec-persistent-data.js
@@ -14,4 +14,31 @@ function testPersistentData() {
     airconsole.storePersistentData("hero", 2, 293);
     expect(AirConsole.postMessage_).toHaveBeenCalledWith(expected_data);
   });
+
+  it ("Should throw an error when storing persistent data without a uid", function() {
+    var value = { key: "hero", value: 2, uid: 293 };
+    var expected_data = { action: "set", key: "persistentstore", value: value };
+
+    try {
+      airconsole.storePersistentData("hero", 2);
+    } catch (e){
+      expect(e).toEqual(new Error("A valid uid must be provided"));
+    }
+  });
+
+  it ("Should throw an error when requesting persistent data without uids", function() {
+    try {
+      airconsole.requestPersistentData();
+    } catch (e){
+      expect(e).toEqual(new Error("A valid array of uids must be provided"));
+    }
+  });
+
+  it ("Should throw an error when requesting persistent data with an empty uids array", function() {
+    try {
+      airconsole.requestPersistentData([]);
+    } catch (e){
+      expect(e).toEqual(new Error("At least one valid uid must be provided"));
+    }
+  });
 }


### PR DESCRIPTION
This makes the uid a required parameter in the requestPersistentData and storePersistentData functions


Visit [airconsole-1.9.0-spec.html](https://htmlpreview.github.io/?https://github.com/AirConsole/airconsole-api/blob/marc-improve-persistent-storage-api/tests/airconsole-1.9.0-spec.html) to run the tests

---

This will be released as part of AirConsole API 1.9.0 along the other API changes to make it possible to provide version migration documentation on https://developers.airconsole.com ahead of release.

This PR will not be merged until the validation based on https://github.com/AirConsole/airconsole-appengine/pull/2432 has concluded.