### PR TITLE
Enable player silencing unless the game uses airconsole-latest

### DIFF
--- a/airconsole-1.9.0.js
+++ b/airconsole-1.9.0.js
@@ -1142,10 +1142,10 @@ AirConsole.prototype.getDefaultPlayerSilencing_ = function() {
   let airconsoleApiVersion = { version: this.version };
   if(referencedAirconsoleAPIScripts.length > 0) {
     airconsoleApiVersion = referencedAirconsoleAPIScripts[0]
-      .match(new RegExp('https?://.*/api/airconsole-(?<version>.*).js'))
-      .groups;
+      .match(new RegExp('https?://.*/api/airconsole-(.*).js'));
   }
-  return airconsoleApiVersion.version !== 'latest' || false;
+  
+  return airconsoleApiVersion.length > 1 && airconsoleApiVersion[1] !== 'latest' || false;
 }
 
 /**

--- a/airconsole-1.9.0.js
+++ b/airconsole-1.9.0.js
@@ -56,10 +56,11 @@ function AirConsole(opts) {
  *           accelerometer and the gyroscope. Only for controllers.
  * @property {boolean} translation - If an AirConsole translation file should
  *           be loaded.
- * @property {boolean} [silence_inactive_players=false] - If set, newly joining devices will be
+ * @property {boolean} [silence_inactive_players] - If set, newly joining devices will be
  *           prompted to wait while an active game is going on.<br />
  *           To start a game round, call setActivePlayers(X) with X larger than 0 eg 1,2,3,...<br />
  *           To finish a game round, call setActivePlayers(0).<br />
+ *           Default: true, unless the game uses the automatically upgrading API version.<br />
  *           See {@link https://developers.airconsole.com/#!/guides/player_silencing Player Silencing Guide} for details.<br />
  *           Added in 1.9.0
  */
@@ -1127,6 +1128,27 @@ AirConsole.prototype.onResume = function() {};
  * ------------------------------------------------------------------------- */
 
 /**
+ * Determines if AirConsole by default should have player silencing enabled or not.
+ * @returns If the player should be silenced based on environment factors.
+ * @private
+ */
+AirConsole.prototype.getDefaultPlayerSilencing_ = function() {
+  const referencedAirconsoleAPIScripts = Array.prototype.slice.call(document.getElementsByTagName('script'),0)
+  .map(it => it.src).filter(it => it.includes('api/airconsole-'));
+  if(referencedAirconsoleAPIScripts.length > 1) {
+    alert('only a single instance of api/airconsole-*.js must be used per screen/controller.')
+    return;
+  }
+  let airconsoleApiVersion = { version: this.version };
+  if(referencedAirconsoleAPIScripts.length > 0) {
+    airconsoleApiVersion = referencedAirconsoleAPIScripts[0]
+      .match(new RegExp('https?://.*/api/airconsole-(?<version>.*).js'))
+      .groups;
+  }
+  return airconsoleApiVersion.version !== 'latest' || false;
+}
+
+/**
  * Initializes the AirConsole.
  * @param {AirConsole~Config} opts - The Config.
  * @private
@@ -1138,7 +1160,10 @@ AirConsole.prototype.init_ = function(opts) {
   me.devices = [];
   me.silencedUpdatesQueue_ = {};
   me.server_time_offset = opts.synchronize_time ? 0 : false;
-  me.silence_inactive_players = opts.silence_inactive_players || false;
+  
+  const defaultPlayerSilencing = me.getDefaultPlayerSilencing_();
+  me.silence_inactive_players = opts.silence_inactive_players || defaultPlayerSilencing;
+  
   window.addEventListener("message", function(event) {
     me.onPostMessage_(event);
   }, false);

--- a/tests/spec/methods/spec-player-silencing.js
+++ b/tests/spec/methods/spec-player-silencing.js
@@ -1,9 +1,12 @@
 function testPlayerSilencing() {
-  function initAirConsole(optional_arguments) {
+  function initAirConsole(constructorArguments, version) {
+    const srcUrl = `http://localhost/api/airconsole-${version || 'latest'}.js`;
+    spyOn(document, 'getElementsByTagName').and.callFake(() => [{ src: srcUrl }]);
+    
     //
     airconsole = new AirConsole({
       setup_document: false,
-      ...(!!optional_arguments ? optional_arguments : {})
+      ...(!!constructorArguments ? constructorArguments : {})
     });
     airconsole.device_id = AirConsole.SCREEN;
 
@@ -18,8 +21,8 @@ function testPlayerSilencing() {
     };
   }
 
-  it("Should not silence players with default AirConsole initialization", function () {
-    initAirConsole();
+  it("Should not silence players with default AirConsole initialization on latest", function () {
+    initAirConsole( undefined, 'latest');
     airconsole.setActivePlayers(2);
 
     expect(airconsole.arePlayersSilenced()).toBe(false);
@@ -235,6 +238,18 @@ function testPlayerSilencing() {
     });
 
     expect(airconsole.onDisconnect).toHaveBeenCalledTimes(0);
+  });
+  
+  const defaultSilencingParameterDeductionnParams = [
+    { description: "Should by default have player silencing enabled for API 1.9.0", input: '1.9.0', result: true },
+    { description: "Should by default have player silencing disabled for latest API", input: 'latest', result: false }
+  ];
+  defaultSilencingParameterDeductionnParams.forEach(parameter => {
+    it(parameter.description, () => {
+      initAirConsole(undefined, parameter.input);
+      
+      expect(airconsole.silence_inactive_players).toBe(parameter.result); 
+    });
   });
 
   function initAirConsoleWithSilencedDevice(connected_id = 1, silenced_id = 2, active_device_id = 0) {


### PR DESCRIPTION
Originally we discussed to have player silencing disabled by default.

Given past experience of adopting powerful new features I would like to slightly alter that for the production release of 1.9.0:
- Player silencing is default disabled if games use `airconsole-latest.js`
- Otherwise it is enabled unless explicitly disabled in the constructor options.

This ensures that the maximum amount of people can benefit from it.