### PR TITLE
Fix player silencing being active when it shouldn't be

### DIFF
--- a/airconsole-1.9.0.js
+++ b/airconsole-1.9.0.js
@@ -1162,7 +1162,7 @@ AirConsole.prototype.init_ = function(opts) {
   me.server_time_offset = opts.synchronize_time ? 0 : false;
   
   const defaultPlayerSilencing = me.getDefaultPlayerSilencing_();
-  me.silence_inactive_players = opts.silence_inactive_players || defaultPlayerSilencing;
+  me.silence_inactive_players = opts.silence_inactive_players !== undefined ? opts.silence_inactive_players : defaultPlayerSilencing;
   
   window.addEventListener("message", function(event) {
     me.onPostMessage_(event);

--- a/tests/spec/methods/spec-player-silencing.js
+++ b/tests/spec/methods/spec-player-silencing.js
@@ -20,16 +20,30 @@ function testPlayerSilencing() {
       custom: {}
     };
   }
-
+  
   it("Should not silence players with default AirConsole initialization on latest", function () {
     initAirConsole( undefined, 'latest');
     airconsole.setActivePlayers(2);
 
     expect(airconsole.arePlayersSilenced()).toBe(false);
   });
+  
+  it("Should silence players with default AirConsole initialization on 1.9.0", function () {
+    initAirConsole( undefined, '1.9.0');
+    airconsole.setActivePlayers(2);
 
-  it("Should not silence players with AirConsole configured to not silence players", function () {
-    initAirConsole({ silence_inactive_players: false });
+    expect(airconsole.arePlayersSilenced()).toBe(true);
+  });
+
+  it("Should not silence players with AirConsole configured to not silence players on 1.9.0", function () {
+    initAirConsole({ silence_inactive_players: false }, '1.9.0');
+    airconsole.setActivePlayers(2);
+
+    expect(airconsole.arePlayersSilenced()).toBe(false);
+  });
+  
+  it("Should not silence players with AirConsole configured to not silence players on latest", function () {
+    initAirConsole({ silence_inactive_players: false }, 'latest');
     airconsole.setActivePlayers(2);
 
     expect(airconsole.arePlayersSilenced()).toBe(false);


### PR DESCRIPTION
The previous logic that aimed to remain compatible with older browser engine had an error in correctly falling through, leading to `silence_inactive_players` always being true when using airconsole-1.9.0.js

This is now addressed and protected against with a regression unit test. 