### PR TITLE
b: Fix subchapter documentation source url generation

### DIFF
--- a/.github/generate-docs.py
+++ b/.github/generate-docs.py
@@ -75,7 +75,7 @@ try:
         line = line.replace(">AirConsole" + id + "<", "><b>&#8627; " + chapter + "</b><")
         if "<h3>Classes</h3><ul><li>" not in line:
           line = line.replace(id, "")
-          line = line.replace("jsdoc_chapters/.js", filename).replace("jsdoc_chapters_.js", filename.replace("/", "_"))
+          line = line.replace("jsdoc_chapters/.js", filename).replace("jsdoc_chapters_.js", filename)
         line = line.replace("<h3>Classes</h3><ul><li><a href=\"AirConsole.html\">AirConsole</a><ul class='methods'>",
                             "<h3>Classes</h3><ul><li><a href=\"AirConsole.html\"><b>AirConsole</b></a><ul class='methods' style='display:none'>")
         if not file.endswith("AirConsole.html"):


### PR DESCRIPTION
This addresses the problem where the sub chapters of the API documentation would point to an invalid api js reference.