### PR TITLE
refactor(getUserMedia): adopt standard Promise resolve/reject semantics

### DIFF
--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -41,3 +41,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs  # The directory containing the generated HTML files
+        keep_files: true  # Preserve other content (e.g. beta/ subdirectory) on gh-pages

--- a/.github/workflows/deploy-beta-docs.yml
+++ b/.github/workflows/deploy-beta-docs.yml
@@ -1,0 +1,40 @@
+name: Deploy Beta Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'beta/airconsole-*.js'
+
+jobs:
+  generate-and-deploy:
+    name: Generate and deploy beta docs
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v4
+
+    - name: Install npm dependencies
+      run: |
+        npm install -g jsdoc@3.6.11
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    # generate-docs.py creates output dir "api-1-11-0" from the input filename
+    - name: Generate beta documentation
+      run: |
+        python .github/generate-docs.py ./beta/airconsole-1.11.0.js
+        yes | cp -rf api-1-11-0/AirConsole.html api-1-11-0/index.html
+
+    - name: Deploy to GitHub Pages (beta subdirectory)
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./api-1-11-0
+        destination_dir: beta  # Deploy to /beta/ subdirectory
+        keep_files: true  # Preserve other content on gh-pages

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,9 +84,9 @@ sequenceDiagram
         Note over Platform,Game: Flow 8: broadcast to other devices
         Platform->>API: device update with _is_userMediaPermission_update: true
         alt granted
-            API-->>Game: onUserMediaAccessGranted(device_id, constraints)
+            API-->>Game: onUserMediaAccessGranted(device_id)
         else denied
-            API-->>Game: onUserMediaAccessDenied(device_id, errorType)
+            API-->>Game: onUserMediaAccessDenied(device_id)
         end
     end
 ```

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,11 +23,11 @@ sequenceDiagram
     Game->>API: getUserMedia(constraints)
     alt Flow 1: early rejection
         Note over API: Validate caller and constraints
-        Note over API: Reject early when device is SCREEN, device_id is undefined, media_permission_pending_ is true, or constraints are invalid
+        Note over API: Reject early when device is SCREEN, device_id is undefined, mediaPermissionPending_ is true, or constraints are invalid
         API-->>Game: Promise rejects with AirConsoleUserMediaError
     else Request accepted
         Note over API: mediaPermissionCallbacks_.set(instance, { resolve, reject })
-        Note over API: media_permission_pending_ = true
+        Note over API: mediaPermissionPending_ = true
         Note over API: start 30s timeout
         API->>Platform: sendEvent_('requestUserMediaPermission', { constraints })
 
@@ -77,7 +77,7 @@ sequenceDiagram
             API-->>Game: Promise rejects with AirConsoleUserMediaError
         end
 
-        Note over API: Guard stale messages with media_permission_pending_
+        Note over API: Guard stale messages with mediaPermissionPending_
     end
 
     rect rgba(230, 230, 255, 0.35)
@@ -101,4 +101,4 @@ Callback storage lives in a `WeakMap`, which keeps resolve and reject handlers a
 
 The 30 second timeout is a safety net. It rejects with `AirConsoleUserMediaError.timeout` if the platform never answers.
 
-`media_permission_pending_` blocks duplicate requests and ignores stale platform messages after cleanup.
+`mediaPermissionPending_` blocks duplicate requests and ignores stale platform messages after cleanup.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 **API** is the AirConsole JS SDK running on the controller. It validates input, tracks pending state, talks to the platform, and bridges browser level failures back to the game.
 
-**Platform** decides whether the permission flow should run through a browser prompt, resolve natively, deny with a reason, or return an error.
+**Platform** decides whether the permission flow should run through a browser prompt, resolve natively, deny with an error type, or return an error.
 
 **Browser** is `navigator.mediaDevices.getUserMedia`, the final source of stream success or browser level failure.
 
@@ -24,7 +24,7 @@ sequenceDiagram
     alt Flow 1: early rejection
         Note over API: Validate caller and constraints
         Note over API: Reject early when device is SCREEN, device_id is undefined, media_permission_pending_ is true, or constraints are invalid
-        API-->>Game: resolve({ success: false, error })
+        API-->>Game: Promise rejects with AirConsoleUserMediaError
     else Request accepted
         Note over API: mediaPermissionCallbacks_.set(instance, { resolve, reject })
         Note over API: media_permission_pending_ = true
@@ -37,13 +37,20 @@ sequenceDiagram
             alt Browser succeeds
                 Browser-->>API: stream
                 API->>Platform: sendEvent_('userMediaPermissionGranted', { constraints })
-                API-->>Game: resolve({ success: true, stream })
+                API-->>Game: Promise resolves with stream
             else Flow 4: browser rejects after promptUserMediaPermission
-                Browser-->>API: error
-                API->>Platform: sendEvent_('userMediaPermissionDenied', { userPromptDuration, error })
-                Platform->>API: event userMediaPermissionDenied with data: { error }
-                API->>API: rejectMediaPermission_(error)
-                API-->>Game: Promise rejects with error
+                Browser-->>API: DOMException error
+                Note over API: cachedMediaError_ = error
+                API->>Platform: sendEvent_('userMediaPermissionDenied', { errorType: error.name })
+                Platform->>API: event userMediaPermissionDenied
+                alt cachedMediaError_ is set
+                    API->>API: rejectMediaPermission_(cachedMediaError_)
+                    API-->>Game: Promise rejects with DOMException
+                else no cached error
+                    API->>API: rejectMediaPermission_(AirConsoleUserMediaError.permissionDenied)
+                    API-->>Game: Promise rejects with AirConsoleUserMediaError
+                end
+                Note over API: cachedMediaError_ cleared in cleanUpMediaPermission_
             end
 
         else Flow 3: platform sends userMediaPermissionGranted
@@ -52,48 +59,46 @@ sequenceDiagram
             alt Browser succeeds
                 Browser-->>API: stream
                 API->>Platform: sendEvent_('userMediaPermissionGranted', { constraints })
-                API-->>Game: resolve({ success: true, stream })
+                API-->>Game: Promise resolves with stream
             else Flow 5: browser rejects after userMediaPermissionGranted
                 Browser-->>API: error
-                API-->>Game: resolve({ success: false, error })
+                API->>API: rejectMediaPermission_(error)
+                API-->>Game: Promise rejects with error
             end
 
-        else Flow 6: platform denies with reason
-            Platform->>API: event userMediaPermissionDenied with data: { reason: 'temporary'|'permanent' }
-            API-->>Game: resolve({ success: false, reason })
+        else Flow 6: platform denies
+            Platform->>API: event userMediaPermissionDenied
+            API->>API: rejectMediaPermission_(AirConsoleUserMediaError.permissionDenied)
+            API-->>Game: Promise rejects with AirConsoleUserMediaError
 
-        else Flow 7: platform sends error directly
-            Platform->>API: event userMediaPermissionDenied with data: { error }
-            API->>API: rejectMediaPermission_(error)
-            API-->>Game: Promise rejects with error
-
-        else Flow 8: timeout
+        else Flow 7: timeout
             Note over API: 30s passes with no platform response
-            API-->>Game: resolve({ success: false, error: 'timeout' })
+            API->>API: rejectMediaPermission_(AirConsoleUserMediaError.timeout)
+            API-->>Game: Promise rejects with AirConsoleUserMediaError
         end
 
         Note over API: Guard stale messages with media_permission_pending_
     end
 
     rect rgba(230, 230, 255, 0.35)
-        Note over Platform,Game: Flow 9: broadcast to other devices
+        Note over Platform,Game: Flow 8: broadcast to other devices
         Platform->>API: device update with _is_userMediaPermission_update: true
         alt granted
             API-->>Game: onUserMediaAccessGranted(device_id, constraints)
         else denied
-            API-->>Game: onUserMediaAccessDenied(device_id, reason)
+            API-->>Game: onUserMediaAccessDenied(device_id, errorType)
         end
     end
 ```
 
 ## Key Design Decisions
 
-Platform denials resolve the Promise with `{ success: false, ... }`. Browser failures use Promise rejection when the platform echoes a browser error back through `userMediaPermissionDenied`, but native controller browser failures after `userMediaPermissionGranted` resolve with `{ success: false, error }` instead.
+The Promise resolves with the `MediaStream` on success and rejects with an `Error` on failure. Early rejections (SCREEN device, not ready, already pending, invalid constraints) return `Promise.reject(createAirConsoleUserMediaError(...))` directly. Platform denials, timeouts, and browser failures all go through `rejectMediaPermission_`, which calls the stored `reject` callback and always rejects with a typed `AirConsoleUserMediaError` — except when a cached `DOMException` is present, which is passed through directly to preserve `instanceof` checks.
 
-Browser prompt failures use a platform echo pattern. The API sends `sendEvent_('userMediaPermissionDenied', { userPromptDuration, error })`, waits for the platform to echo `userMediaPermissionDenied` with `data: { error }`, then calls `rejectMediaPermission_(error)`.
+Browser prompt failures use a cache-and-echo pattern. When the browser rejects with a `DOMException`, the API stores the error in `cachedMediaError_` and sends `sendEvent_('userMediaPermissionDenied', { errorType: error.name })` to the platform. When the platform echoes back `userMediaPermissionDenied`, the API checks `cachedMediaError_`: if set, it calls `rejectMediaPermission_(cachedMediaError_)` to preserve `instanceof DOMException` for the game; if not set, it rejects with a generic `AirConsoleUserMediaError.permissionDenied`. `cachedMediaError_` is cleared in `cleanUpMediaPermission_`.
 
 Callback storage lives in a `WeakMap`, which keeps resolve and reject handlers attached to the SDK instance without exposing them on public state.
 
-The 30 second timeout is a safety net. It resolves `{ success: false, error: 'timeout' }` if the platform never answers.
+The 30 second timeout is a safety net. It rejects with `AirConsoleUserMediaError.timeout` if the platform never answers.
 
 `media_permission_pending_` blocks duplicate requests and ignores stale platform messages after cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,14 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-### Changed
+### Added 
 
-- Changed `getUserMedia` browser-error rejection flow: controller now sends error to platform via `sendEvent_('userMediaPermissionDenied', { userPromptDuration, error })`; platform echoes back `userMediaPermissionDenied` with `data: { error }` which triggers `rejectMediaPermission_` locally, replacing the previous direct local rejection.
+- New `AirConsole.getUserMedia` API for requesting access to the microphone on the controller.
+  - Matches the browser's `getUserMedia` API on the controller.
+  - As per 1.11.0, only the `audio` constraint is supported
+  - The support is consistent for browser based controllers as well as the native AirConsole controller for Android and iOS.
+  - `AirConsole.USERMEDIA_ERROR_TYPE` provides information in why the request was rejected: permant, temporary or in the controller application: if the application is outdated and the user needs to update it.
+  - The API is designed to be future proof, allowing for the addition of video support in the future without breaking changes.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,19 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.0.0/
   - Matches the browser's `getUserMedia` API on the controller.
   - As per 1.11.0, only the `audio` constraint is supported
   - The support is consistent for browser based controllers as well as the native AirConsole controller for Android and iOS.
-  - `AirConsole.USERMEDIA_ERROR_TYPE` provides information in why the request was rejected: permant, temporary or in the controller application: if the application is outdated and the user needs to update it.
   - The API is designed to be future proof, allowing for the addition of video support in the future without breaking changes.
-
-### Added
-
 - Added `ARCHITECTURE.md` with mermaid sequence diagram documenting the full media permission flow.
+
+### Changed
+
+- `getUserMedia` now uses standard Promise resolve/reject semantics: resolves with `MediaStream` on success, rejects with typed `Error` on failure. Removes the `{ success, stream?, reason?, error? }` envelope.
+- Browser `DOMException` objects are preserved across the platform roundtrip via a cache-and-echo pattern (`cachedMediaError_`), so `error instanceof DOMException` works in `.catch()`.
+- Video constraints are now explicitly rejected with `USERMEDIA_ERROR.invalidConstraints` instead of being silently ignored.
+- `onUserMediaAccessGranted(device_id)` and `onUserMediaAccessDenied(device_id)` no longer carry a second parameter.
+
+### Removed
+
+- Removed `MEDIA_PERMISSION_DENIED` enum (`temporary`/`permanent` distinction). Platform denials now reject with `AirConsoleUserMediaError("PermissionDenied")`; browser denials pass through the original `DOMException`.
 
 ## [1.10.0] - 2026-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Release notes follow the [keep a changelog](https://keepachangelog.com/en/1.0.0/
 
 - `getUserMedia` now uses standard Promise resolve/reject semantics: resolves with `MediaStream` on success, rejects with typed `Error` on failure. Removes the `{ success, stream?, reason?, error? }` envelope.
 - Browser `DOMException` objects are preserved across the platform roundtrip via a cache-and-echo pattern (`cachedMediaError_`), so `error instanceof DOMException` works in `.catch()`.
-- Video constraints are now explicitly rejected with `USERMEDIA_ERROR.invalidConstraints` instead of being silently ignored.
+- Video constraints are now explicitly rejected with `USER_MEDIA_ERROR_TYPE.invalidConstraints` instead of being silently ignored.
 - `onUserMediaAccessGranted(device_id)` and `onUserMediaAccessDenied(device_id)` no longer carry a second parameter.
 
 ### Removed

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -133,25 +133,25 @@ AirConsole.VIBRATE = {
 };
 
 /**
- * Possible reasons for media permission denial when calling AirConsole.getUserMedia().
+ * Possible error types for media permission denial when calling AirConsole.getUserMedia().
  *
  * When a user denies access to audio/video media streams, the getUserMedia promise resolves with
- * a response containing an additional `reason` field indicating whether the denial is temporary
- * (getUserMedia can be requested again without user action to change security settings) or permanent (user must first
- * change permissions in the browser or for the application).
+ * a response containing an `errorType` field indicating the nature of the denial.
  *
- * @typedef {Object} AirConsole.MEDIA_PERMISSION_DENIED
- * @property {string} temporary - User temporarily denied permission.
- * @property {string} permanent - User permanently denied permission.
+ * @typedef {Object} AirConsole.USERMEDIA_ERROR_TYPE
+ * @property {string} temporary - User temporarily denied permission (can retry).
+ * @property {string} permanent - User permanently denied permission (must change settings).
+ * @property {string} outdated - Device software is too old to support this feature.
  *
  * @example
  * For an example see
  * @see AirConsole.prototype.onUserMediaAccessDenied
  * @see AirConsole.prototype.getUserMedia
  */
-AirConsole.MEDIA_PERMISSION_DENIED = {
-  temporary: "temporary",
-  permanent: "permanent",
+AirConsole.USERMEDIA_ERROR_TYPE = {
+  temporary: "AirConsole.temporary",
+  permanent: "AirConsole.permanent",
+  outdated: "AirConsole.outdated",
 };
 
 /**
@@ -760,24 +760,24 @@ AirConsole.prototype.onUserMediaAccessGranted = function(device_id, constraints)
  * On the requesting device, the getUserMedia promise will provide the result immediately.
  * @abstract
  * @param {number} device_id - The device_id of the controller.
- * @param {AirConsole.MEDIA_PERMISSION_DENIED} reason - The reason for denial. One of the values from AirConsole.MEDIA_PERMISSION_DENIED.
+ * @param {AirConsole.USERMEDIA_ERROR_TYPE} errorType - The type of denial. One of the values from AirConsole.USERMEDIA_ERROR_TYPE.
  *
  * @example
- * airconsole.onUserMediaAccessDenied = function (device_id, reason) {
- *   if (reason === AirConsole.MEDIA_PERMISSION_DENIED.temporary) {
+ * airconsole.onUserMediaAccessDenied = function (device_id, errorType) {
+ *   if (errorType === AirConsole.USERMEDIA_ERROR_TYPE.temporary) {
  *     console.log('Controller ' + device_id + ' temporarily denied media access');
  *     // You could prompt the user on the controller to try again
- *   } else if (reason === AirConsole.MEDIA_PERMISSION_DENIED.permanent) {
+ *   } else if (errorType === AirConsole.USERMEDIA_ERROR_TYPE.permanent) {
  *     console.log('Controller ' + device_id + ' permanently denied media access');
  *     // Disable features that require microphone access for this controller
  *   }
  * };
  *
- * @see AirConsole.MEDIA_PERMISSION_DENIED
+ * @see AirConsole.USERMEDIA_ERROR_TYPE
  * @see AirConsole.prototype.getUserMedia
  * @see AirConsole.prototype.onUserMediaAccessGranted
  */
-AirConsole.prototype.onUserMediaAccessDenied = function (device_id, reason) {};
+AirConsole.prototype.onUserMediaAccessDenied = function (device_id, errorType) {};
 
 /**
  * Module-private storage for pending getUserMedia promise callbacks.
@@ -798,7 +798,7 @@ const mediaPermissionCallbacks_ = new WeakMap();
  * Requests media permissions (e.g. microphone or camera) for the controller.
  * Can only be called by a controller (not the screen).
  * @param {Object.<AirConsole~GetUserMediaConstraint>} constraints - User Media Request constraints.
- * @return {Promise.<{success: boolean, stream: MediaStream=, reason: string=, error: Error=}>}
+ * @return {Promise.<{success: boolean, stream: MediaStream=, errorType: string=, error: Error=}>}
  *   The Promise follows the same rejection semantics as the native
  *   {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia MediaDevices.getUserMedia}:
  *   native browser errors (e.g. NotAllowedError, NotFoundError) cause the Promise to reject.
@@ -806,7 +806,7 @@ const mediaPermissionCallbacks_ = new WeakMap();
  *   {success: false, ...} so they can be handled in the .then() callback.
  *
  *   On success: {success: true, stream: <MediaStream>}
- *   On platform denial: {success: false, reason: <string from AirConsole.MEDIA_PERMISSION_DENIED>}
+ *   On platform denial: {success: false, errorType: <string from AirConsole.USERMEDIA_ERROR_TYPE>}
  *   On other error: {success: false, error: <Error>}
  *
  *   Note: callers are responsible for stopping stream tracks when the stream is no longer needed:
@@ -816,10 +816,10 @@ const mediaPermissionCallbacks_ = new WeakMap();
  * airconsole.getUserMedia({ audio: true }).then(function(result) {
  *   if (result.success) {
  *     console.log('Media access granted', result.stream);
- *   } else if (result.reason === AirConsole.MEDIA_PERMISSION_DENIED.temporary) {
+ *   } else if (result.errorType === AirConsole.USERMEDIA_ERROR_TYPE.temporary) {
  *     console.log('User temporarily denied media access');
  *     // Try requesting media access again later, e.g. after a user interaction
- *   } else if (result.reason === AirConsole.MEDIA_PERMISSION_DENIED.permanent) {
+ *   } else if (result.errorType === AirConsole.USERMEDIA_ERROR_TYPE.permanent) {
  *     console.log('User permanently denied media access');
  *   } else if (result.error) {
  *     console.error('Error requesting media access:', result.error);
@@ -829,7 +829,7 @@ const mediaPermissionCallbacks_ = new WeakMap();
  *   console.error('Native browser media access error:', error);
  * });
  *
- * @see AirConsole.MEDIA_PERMISSION_DENIED
+ * @see AirConsole.USERMEDIA_ERROR_TYPE
  * @see AirConsole.prototype.onUserMediaAccessGranted
  * @see AirConsole.prototype.onUserMediaAccessDenied
  */
@@ -870,6 +870,7 @@ AirConsole.prototype.cleanUpMediaPermission_ = function cleanUpMediaPermission_(
   this.media_permission_pending_ = false;
   this.media_permission_constraints_ = undefined;
   this.media_permission_timeout_ = undefined;
+  this.cachedMediaError_ = null;
   mediaPermissionCallbacks_.delete(this);
 }
 
@@ -1567,11 +1568,11 @@ AirConsole.prototype.onPostMessage_ = function(event) {
         }
         if (data.device_data._is_userMediaPermission_update) {
           if (data.device_data.userMediaPermission) {
-            const { granted, reason, constraints } = data.device_data.userMediaPermission;
+            const { granted, errorType, constraints } = data.device_data.userMediaPermission;
             if (granted) {
               me.onUserMediaAccessGranted(sender, constraints);
             } else {
-              me.onUserMediaAccessDenied(sender, reason || AirConsole.MEDIA_PERMISSION_DENIED.temporary);
+              me.onUserMediaAccessDenied(sender, errorType || AirConsole.USERMEDIA_ERROR_TYPE.temporary);
             }
           }
         }
@@ -1683,26 +1684,27 @@ AirConsole.prototype.onPostMessage_ = function(event) {
     }
 
     if (type === 'userMediaPermissionDenied') {
-      // Validate reason against the known enum to prevent unexpected values reaching callers.
-      const validReasons = [
-        AirConsole.MEDIA_PERMISSION_DENIED.temporary,
-        AirConsole.MEDIA_PERMISSION_DENIED.permanent
+      // Validate errorType against the known enum to prevent unexpected values reaching callers.
+      const validErrorTypes = [
+        AirConsole.USERMEDIA_ERROR_TYPE.temporary,
+        AirConsole.USERMEDIA_ERROR_TYPE.permanent,
+        AirConsole.USERMEDIA_ERROR_TYPE.outdated
       ];
 
-      // If the response contains the error object, this signifies the getUserMedia is expected to execute the
-      // rejection.
-      const error = data.data?.error;
-      if (error) {
-        me.rejectMediaPermission_(error);
-        return;
+      const rawErrorType = data.data?.errorType;
+      const errorType = validErrorTypes.indexOf(rawErrorType) !== -1
+        ? rawErrorType
+        : AirConsole.USERMEDIA_ERROR_TYPE.temporary;
+
+      // If a browser error was cached (from a local getUserMedia failure that was sent to platform),
+      // reject with the original error object to preserve instanceof checks.
+      if (me.cachedMediaError_ && rawErrorType.indexOf("AirConsole.") === -1) {
+        const cachedError = me.cachedMediaError_;
+        me.cachedMediaError_ = null;
+        me.rejectMediaPermission_(cachedError);
+      } else {
+        me.resolveMediaPermission_({ success: false, errorType });
       }
-
-      const rawReason = data.data?.reason;
-      const reason = validReasons.indexOf(rawReason) !== -1
-        ? rawReason
-        : AirConsole.MEDIA_PERMISSION_DENIED.temporary;
-
-      me.resolveMediaPermission_({ success: false, reason });
     } else if (type === 'userMediaPermissionGranted' || type === 'promptUserMediaPermission') {
       const userPromptStartTime = performance.now();
 
@@ -1729,9 +1731,11 @@ AirConsole.prototype.onPostMessage_ = function(event) {
             me.resolveMediaPermission_({ success: false, error });
           } else if (type === 'promptUserMediaPermission') {
             // Web-based controller: browser denied the permission dialog.
+            // Cache the error so we can reject with it when platform echoes back errorType.
+            me.cachedMediaError_ = error;
             // Always notify the platform regardless of error type so its state machine can recover.
             const userPromptDuration = performance.now() - userPromptStartTime;
-            me.sendEvent_('userMediaPermissionDenied', { userPromptDuration, error });
+            me.sendEvent_('userMediaPermissionDenied', { errorType: error.name, userPromptDuration });
           }
         }
       );

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -881,9 +881,11 @@ AirConsole.prototype.rejectMediaPermission_ = function rejectMediaPermission_(er
  */
 AirConsole.prototype.destroy = function destroy() {
   window.removeEventListener('message', this.messageEventListener_);
-  if (this.mediaPermissionTimeout_) {
+  if (this.mediaPermissionPending_) {
+    this.rejectMediaPermission_(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.timeout));
+  } else if (this.mediaPermissionTimeout_) {
     clearTimeout(this.mediaPermissionTimeout_);
-    this.mediaPermissionTimeout_ = null;
+    this.mediaPermissionTimeout_ = undefined;
   }
 };
 
@@ -1698,6 +1700,9 @@ AirConsole.prototype.onPostMessage_ = function(event) {
           me.resolveMediaPermission_(stream);
         },
         function failure(error) {
+          if (!me.mediaPermissionPending_) {
+            return;
+          }
           // Native controller: platform already granted permission but stream open failed.
           if (type === 'userMediaPermissionGranted') {
             me.rejectMediaPermission_(error);

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -724,18 +724,16 @@ AirConsole.prototype.vibrate = function(options) {
  * On the requesting device, the getUserMedia promise will provide the result immediately.
  * @abstract
  * @param {number} device_id - The device_id of the controller that was granted access.
- * @param {AirConsole~GetUserMediaConstraint|undefined} constraints - The constraints that were granted (e.g. {audio:
- *   true}). May be undefined if the platform does not include constraint information in the update payload.
  *
  * @example
- * airconsole.onUserMediaAccessGranted = function (device_id, constraints) {
- *    console.info('Controller ' + device_id + ' denied media access for ', JSON.stringify(constraints));
+ * airconsole.onUserMediaAccessGranted = function (device_id) {
+ *    console.info('Controller ' + device_id + ' was granted media access');
  * };
  *
  * @see AirConsole.prototype.getUserMedia
  * @see AirConsole.prototype.onUserMediaAccessDenied
  */
-AirConsole.prototype.onUserMediaAccessGranted = function(device_id, constraints) {};
+AirConsole.prototype.onUserMediaAccessGranted = function(device_id) {};
 
 /**
  * Gets called on all other devices in the game as a result of to a denied request to getUserMedia on the specific
@@ -743,18 +741,16 @@ AirConsole.prototype.onUserMediaAccessGranted = function(device_id, constraints)
  * On the requesting device, the getUserMedia promise will provide the result immediately.
  * @abstract
  * @param {number} device_id - The device_id of the controller.
- * @param {AirConsole~GetUserMediaConstraint|undefined} constraints - The constraints that were granted (e.g. {audio:
- *   true}). May be undefined if the platform does not include constraint information in the update payload.
  *
  * @example
- * airconsole.onUserMediaAccessDenied = function (device_id, constraints) {
-*    console.info('Controller ' + device_id + ' denied media access for ', JSON.stringify(constraints));
+ * airconsole.onUserMediaAccessDenied = function (device_id) {
+ *    console.info('Controller ' + device_id + ' was denied media access');
  * };
  *
  * @see AirConsole.prototype.getUserMedia
  * @see AirConsole.prototype.onUserMediaAccessGranted
  */
-AirConsole.prototype.onUserMediaAccessDenied = function (device_id, constraints) {};
+AirConsole.prototype.onUserMediaAccessDenied = function (device_id) {};
 
 /**
  * Module-private storage for pending getUserMedia promise callbacks.
@@ -1542,9 +1538,9 @@ AirConsole.prototype.onPostMessage_ = function(event) {
           if (data.device_data.userMediaPermission) {
             const { granted } = data.device_data.userMediaPermission;
             if (granted) {
-              me.onUserMediaAccessGranted(sender, me.mediaPermissionConstraints_);
+              me.onUserMediaAccessGranted(sender);
             } else {
-              me.onUserMediaAccessDenied(sender, me.mediaPermissionConstraints_);
+              me.onUserMediaAccessDenied(sender);
             }
           }
         }
@@ -1678,9 +1674,8 @@ AirConsole.prototype.onPostMessage_ = function(event) {
           // Note: 'userMediaPermissionGranted' is both sent upward (controller → platform) and
           // received downward (platform → controller for native controllers). The direction is
           // determined by context: outbound is sent here; inbound is handled by this event branch.
-          const grantedConstraints = me.mediaPermissionConstraints_;
           me.sendEvent_('userMediaPermissionGranted', {
-            constraints: grantedConstraints,
+            constraints: me.mediaPermissionConstraints_,
           });
           me.resolveMediaPermission_(stream);
         },

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -826,7 +826,7 @@ AirConsole.prototype.getUserMedia = function getUserMedia(constraints) {
   if (this.mediaPermissionPending_) {
     return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.alreadyPending));
   }
-  if (!constraints) {
+  if (!constraints || !constraints.audio) {
     return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
   }
   if (!!constraints.video) {

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -815,7 +815,7 @@ AirConsole.prototype.getUserMedia = function getUserMedia(constraints) {
   if (this.device_id === undefined) {
     return Promise.reject(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.notReady));
   }
-  if (this.media_permission_pending_) {
+  if (this.mediaPermissionPending_) {
     return Promise.reject(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.alreadyPending));
   }
   if (!constraints || !('audio' in constraints || 'video' in constraints)) {
@@ -824,10 +824,10 @@ AirConsole.prototype.getUserMedia = function getUserMedia(constraints) {
 
   var me = this;
   return new Promise(function (resolve, reject) {
-    me.media_permission_constraints_ = constraints;
-    me.media_permission_pending_ = true;
+    me.mediaPermissionConstraints_ = constraints;
+    me.mediaPermissionPending_ = true;
     mediaPermissionCallbacks_.set(me, { resolve: resolve, reject: reject });
-    me.media_permission_timeout_ = setTimeout(function() {
+    me.mediaPermissionTimeout_ = setTimeout(function() {
       me.rejectMediaPermission_(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.timeout));
     }, 30000);
 
@@ -838,10 +838,10 @@ AirConsole.prototype.getUserMedia = function getUserMedia(constraints) {
 };
 
 AirConsole.prototype.cleanUpMediaPermission_ = function cleanUpMediaPermission_() {
-  clearTimeout(this.media_permission_timeout_);
-  this.media_permission_pending_ = false;
-  this.media_permission_constraints_ = undefined;
-  this.media_permission_timeout_ = undefined;
+  clearTimeout(this.mediaPermissionTimeout_);
+  this.mediaPermissionPending_ = false;
+  this.mediaPermissionConstraints_ = undefined;
+  this.mediaPermissionTimeout_ = undefined;
   this.cachedMediaError_ = null;
   mediaPermissionCallbacks_.delete(this);
 }
@@ -867,9 +867,9 @@ AirConsole.prototype.rejectMediaPermission_ = function rejectMediaPermission_(er
  */
 AirConsole.prototype.destroy = function destroy() {
   window.removeEventListener('message', this.messageEventListener_);
-  if (this.media_permission_timeout_) {
-    clearTimeout(this.media_permission_timeout_);
-    this.media_permission_timeout_ = null;
+  if (this.mediaPermissionTimeout_) {
+    clearTimeout(this.mediaPermissionTimeout_);
+    this.mediaPermissionTimeout_ = null;
   }
 };
 
@@ -1542,9 +1542,9 @@ AirConsole.prototype.onPostMessage_ = function(event) {
           if (data.device_data.userMediaPermission) {
             const { granted } = data.device_data.userMediaPermission;
             if (granted) {
-              me.onUserMediaAccessGranted(sender, me.media_permission_constraints_);
+              me.onUserMediaAccessGranted(sender, me.mediaPermissionConstraints_);
             } else {
-              me.onUserMediaAccessDenied(sender, me.media_permission_constraints_);
+              me.onUserMediaAccessDenied(sender, me.mediaPermissionConstraints_);
             }
           }
         }
@@ -1651,7 +1651,7 @@ AirConsole.prototype.onPostMessage_ = function(event) {
 
     // Guard: ignore stale platform messages that arrive after state has been cleaned up
     // (e.g. after the 30-second timeout has already resolved the pending Promise).
-    if (!me.media_permission_pending_) {
+    if (!me.mediaPermissionPending_) {
       return;
     }
 
@@ -1667,9 +1667,9 @@ AirConsole.prototype.onPostMessage_ = function(event) {
         me.rejectMediaPermission_(error);
       }
     } else if (type === 'userMediaPermissionGranted' || type === 'promptUserMediaPermission') {
-      navigator.mediaDevices.getUserMedia(me.media_permission_constraints_).then(
+      navigator.mediaDevices.getUserMedia(me.mediaPermissionConstraints_).then(
         function success(stream) {
-          if (!me.media_permission_pending_) {
+          if (!me.mediaPermissionPending_) {
             // Timeout fired while the browser permission dialog was still open;
             // the outer Promise is already settled — stop the orphaned stream to release hardware.
             stream.getTracks().forEach(function (t) { t.stop(); });
@@ -1678,7 +1678,7 @@ AirConsole.prototype.onPostMessage_ = function(event) {
           // Note: 'userMediaPermissionGranted' is both sent upward (controller → platform) and
           // received downward (platform → controller for native controllers). The direction is
           // determined by context: outbound is sent here; inbound is handled by this event branch.
-          const grantedConstraints = me.media_permission_constraints_;
+          const grantedConstraints = me.mediaPermissionConstraints_;
           me.sendEvent_('userMediaPermissionGranted', {
             constraints: grantedConstraints,
           });

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -1698,13 +1698,13 @@ AirConsole.prototype.onPostMessage_ = function(event) {
       ];
 
       const rawErrorType = data.data?.errorType;
-      const errorType = validErrorTypes.indexOf(rawErrorType) !== -1
+      const errorType = rawErrorType && validErrorTypes.indexOf(rawErrorType) !== -1
         ? rawErrorType
         : AirConsole.USERMEDIA_ERROR_TYPE.temporary;
 
       // If a browser error was cached (from a local getUserMedia failure that was sent to platform),
       // reject with the original error object to preserve instanceof checks.
-      if (me.cachedMediaError_ && rawErrorType.indexOf("AirConsole.") === -1) {
+      if (me.cachedMediaError_) {
         const cachedError = me.cachedMediaError_;
         me.cachedMediaError_ = null;
         me.rejectMediaPermission_(cachedError);

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -1735,13 +1735,17 @@ AirConsole.prototype.onPostMessage_ = function(event) {
           // Native controller: platform already granted permission but stream open failed.
           if (type === 'userMediaPermissionGranted') {
             me.resolveMediaPermission_({ success: false, error });
-          } else if (type === 'promptUserMediaPermission') {
-            // Web-based controller: browser denied the permission dialog.
-            // Cache the error so we can reject with it when platform echoes back errorType.
-            me.cachedMediaError_ = error;
-            // Always notify the platform regardless of error type so its state machine can recover.
-            const userPromptDuration = performance.now() - userPromptStartTime;
-            me.sendEvent_('userMediaPermissionDenied', { errorType: error.name, userPromptDuration });
+          } else {
+            if (type === 'userMediaPermissionDenied') {
+              // Always notify the platform regardless of error type so its state machine can recover.
+              const userPromptDuration = performance.now() - userPromptStartTime;
+              me.sendEvent_('userMediaPermissionDenied', { errorType: error.name, userPromptDuration });
+            } else if (error instanceof DOMException) {
+              // Web-based controller: browser denied the permission dialog.
+              // Cache the error so we can reject with it when platform echoes back errorType.
+              me.cachedMediaError_ = error;
+              me.sendEvent_('userMediaPermissionDenied', { errorType: error.name });
+            }
           }
         }
       );

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -845,7 +845,7 @@ AirConsole.prototype.getUserMedia = function getUserMedia(constraints) {
     mediaPermissionCallbacks_.set(me, { resolve: resolve, reject: reject });
     me.mediaPermissionTimeout_ = setTimeout(function() {
       me.rejectMediaPermission_(new AirConsoleUserMediaError(AirConsole.USER_MEDIA_ERROR_TYPE.timeout));
-    }, 30000);
+    }, 45000);
 
     // Send the request to the platform to decide where and how the user media request needs to take place based on
     //  browser or controller environment.
@@ -1710,7 +1710,7 @@ AirConsole.prototype.onPostMessage_ = function(event) {
             me.rejectMediaPermission_(error);
           } else {
             me.cachedMediaError_ = error;
-            me.sendEvent_('userMediaPermissionDenied', { errorType: error.name });
+            me.sendEvent_('userMediaPermissionDenied');
           }
         }
       );

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -818,27 +818,21 @@ const mediaPermissionCallbacks_ = new WeakMap();
  */
 AirConsole.prototype.getUserMedia = function getUserMedia(constraints) {
   if (this.device_id === AirConsole.SCREEN) {
-    console.error(`AirConsole.getUserMedia not supported on screen`);
     return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.notSupportedOnScreen));
   }
   if (this.device_id === undefined) {
-    console.error(`AirConsole.getUserMedia requires device to be initialized`);
     return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.notReady));
   }
   if (this.mediaPermissionPending_) {
-    console.error(`AirConsole.getUserMedia already has a pending request`);
     return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.alreadyPending));
   }
   if (!constraints) {
-    console.error(`AirConsole.getUserMedia requires constraints to be provided`);
     return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
   }
   if (!!constraints.video) {
-    console.error(`AirConsole.getUserMedia does not support video, please remove video from the constraints`);
     return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
   }
   if (!('audio' in constraints)) {
-    console.error(`AirConsole.getUserMedia requires audio constraints to be provided`);
     return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
   }
 
@@ -1705,7 +1699,6 @@ AirConsole.prototype.onPostMessage_ = function(event) {
         },
         function failure(error) {
           // Native controller: platform already granted permission but stream open failed.
-          // TODO(marc): Is this case still relevant?
           if (type === 'userMediaPermissionGranted') {
             me.rejectMediaPermission_(error);
           } else {

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -136,7 +136,7 @@ AirConsole.VIBRATE = {
  * Error message identifiers returned in the `error.message` field of a failed getUserMedia result.
  * These follow the same single-word naming convention as browser DOMException names.
  *
- * @typedef {Object} AirConsole.USERMEDIA_ERROR
+ * @typedef {Object} AirConsole.USER_MEDIA_ERROR_TYPE
  * @property {string} notSupportedOnScreen - getUserMedia cannot be called on the screen device.
  * @property {string} notReady - AirConsole is not yet ready (device_id not assigned).
  * @property {string} alreadyPending - A getUserMedia request is already in progress.
@@ -146,7 +146,7 @@ AirConsole.VIBRATE = {
  *
  * @see AirConsole.prototype.getUserMedia
  */
-AirConsole.USERMEDIA_ERROR = {
+AirConsole.USER_MEDIA_ERROR_TYPE = {
   notSupportedOnScreen: "NotSupportedOnScreen",
   notReady: "NotReady",
   alreadyPending: "AlreadyPending",
@@ -161,7 +161,7 @@ AirConsole.USERMEDIA_ERROR = {
  *
  * @extends {Error}
  *
- * @param {AirConsole.USERMEDIA_ERROR} message - The message is of type AirConsole.USERMEDIA_ERROR.
+ * @param {AirConsole.USER_MEDIA_ERROR_TYPE} message - The message is of type AirConsole.USER_MEDIA_ERROR_TYPE.
  */
 class AirConsoleUserMediaError extends Error {
   constructor(message) {
@@ -737,7 +737,8 @@ AirConsole.prototype.vibrate = function(options) {
 /**
  * Gets called on all other devices in the game as a result of to a successful request to getUserMedia on the specific
  *  device with device_id.
- * On the requesting device, the getUserMedia promise will provide the result immediately.
+ * On the requesting device, this callback is not invoked at this time.
+ * The requesting device currently needs to rely on the getUserMedia promise which will provide the result at the point of promise resolution.
  * @abstract
  * @param {number} device_id - The device_id of the controller that was granted access.
  *
@@ -754,7 +755,8 @@ AirConsole.prototype.onUserMediaAccessGranted = function(device_id) {};
 /**
  * Gets called on all other devices in the game as a result of to a denied request to getUserMedia on the specific
  *  device with device_id.
- * On the requesting device, the getUserMedia promise will provide the result immediately.
+ * On the requesting device, this callback is not invoked at this time.
+ * The requesting device currently needs to rely on the getUserMedia promise which will provide the result at the point of promise resolution.
  * @abstract
  * @param {number} device_id - The device_id of the controller.
  *
@@ -787,9 +789,9 @@ const mediaPermissionCallbacks_ = new WeakMap();
  *
  * @param {AirConsole~GetUserMediaConstraint} constraints - Media constraints. Must include `audio: true`.
  *   Video constraints are not supported and will cause the promise to reject with
- *   {@link AirConsole.USERMEDIA_ERROR}.invalidConstraints.
+ *   {@link AirConsole.USER_MEDIA_ERROR_TYPE}.invalidConstraints.
  * @return {Promise<MediaStream>} Resolves with the granted {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaStream MediaStream}
- *   on success. Rejects with {AirConsoleUserMediaError} (see {@link AirConsole.USERMEDIA_ERROR}) for
+ *   on success. Rejects with {AirConsoleUserMediaError} (see {@link AirConsole.USER_MEDIA_ERROR_TYPE}) for
  *   AirConsole-specific failures, or with a native
  *   {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia DOMException}
  *   (e.g. `NotAllowedError`, `NotFoundError`) when the browser itself denies the request.
@@ -804,7 +806,7 @@ const mediaPermissionCallbacks_ = new WeakMap();
  *   // stream.getTracks().forEach(function(t) { t.stop(); });
  * }).catch(function(error) {
  *   if (error.name === 'AirConsole.UserMediaError') {
- *     // AirConsole-specific error, see AirConsole.USERMEDIA_ERROR for possible values
+ *     // AirConsole-specific error, see AirConsole.USER_MEDIA_ERROR_TYPE for possible values
  *     console.error('AirConsole media error:', error.message);
  *   } else {
  *     // Native browser error (e.g. NotAllowedError, NotFoundError, AbortError)
@@ -812,28 +814,28 @@ const mediaPermissionCallbacks_ = new WeakMap();
  *   }
  * });
  *
- * @see AirConsole.USERMEDIA_ERROR
+ * @see AirConsole.USER_MEDIA_ERROR_TYPE
  * @see AirConsole.prototype.onUserMediaAccessGranted
  * @see AirConsole.prototype.onUserMediaAccessDenied
  */
 AirConsole.prototype.getUserMedia = function getUserMedia(constraints) {
   if (this.device_id === AirConsole.SCREEN) {
-    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.notSupportedOnScreen));
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USER_MEDIA_ERROR_TYPE.notSupportedOnScreen));
   }
   if (this.device_id === undefined) {
-    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.notReady));
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USER_MEDIA_ERROR_TYPE.notReady));
   }
   if (this.mediaPermissionPending_) {
-    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.alreadyPending));
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USER_MEDIA_ERROR_TYPE.alreadyPending));
   }
   if (!constraints || !constraints.audio) {
-    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints));
   }
   if (!!constraints.video) {
-    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints));
   }
   if (!('audio' in constraints)) {
-    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints));
   }
 
   var me = this;
@@ -842,7 +844,7 @@ AirConsole.prototype.getUserMedia = function getUserMedia(constraints) {
     me.mediaPermissionPending_ = true;
     mediaPermissionCallbacks_.set(me, { resolve: resolve, reject: reject });
     me.mediaPermissionTimeout_ = setTimeout(function() {
-      me.rejectMediaPermission_(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.timeout));
+      me.rejectMediaPermission_(new AirConsoleUserMediaError(AirConsole.USER_MEDIA_ERROR_TYPE.timeout));
     }, 30000);
 
     // Send the request to the platform to decide where and how the user media request needs to take place based on
@@ -882,7 +884,7 @@ AirConsole.prototype.rejectMediaPermission_ = function rejectMediaPermission_(er
 AirConsole.prototype.destroy = function destroy() {
   window.removeEventListener('message', this.messageEventListener_);
   if (this.mediaPermissionPending_) {
-    this.rejectMediaPermission_(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.timeout));
+    this.rejectMediaPermission_(new AirConsoleUserMediaError(AirConsole.USER_MEDIA_ERROR_TYPE.timeout));
   } else if (this.mediaPermissionTimeout_) {
     clearTimeout(this.mediaPermissionTimeout_);
     this.mediaPermissionTimeout_ = undefined;
@@ -1679,7 +1681,7 @@ AirConsole.prototype.onPostMessage_ = function(event) {
         me.cachedMediaError_ = null;
         me.rejectMediaPermission_(cachedError);
       } else {
-        const error = new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.permissionDenied);
+        const error = new AirConsoleUserMediaError(AirConsole.USER_MEDIA_ERROR_TYPE.permissionDenied);
         me.rejectMediaPermission_(error);
       }
     } else if (type === 'userMediaPermissionGranted' || type === 'promptUserMediaPermission') {

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -133,28 +133,6 @@ AirConsole.VIBRATE = {
 };
 
 /**
- * Possible error types for media permission denial when calling AirConsole.getUserMedia().
- *
- * When a user denies access to audio/video media streams, the getUserMedia promise resolves with
- * a response containing an `errorType` field indicating the nature of the denial.
- *
- * @typedef {Object} AirConsole.USERMEDIA_ERROR_TYPE
- * @property {string} temporary - User temporarily denied permission (can retry).
- * @property {string} permanent - User permanently denied permission (must change settings).
- * @property {string} outdated - Device software is too old to support this feature.
- *
- * @example
- * For an example see
- * @see AirConsole.prototype.onUserMediaAccessDenied
- * @see AirConsole.prototype.getUserMedia
- */
-AirConsole.USERMEDIA_ERROR_TYPE = {
-  temporary: "AirConsole.temporary",
-  permanent: "AirConsole.permanent",
-  outdated: "AirConsole.outdated",
-};
-
-/**
  * Error message identifiers returned in the `error.message` field of a failed getUserMedia result.
  * These follow the same single-word naming convention as browser DOMException names.
  *
@@ -173,8 +151,8 @@ AirConsole.USERMEDIA_ERROR = {
   alreadyPending: "AlreadyPending",
   invalidConstraints: "InvalidConstraints",
   timeout: "Timeout",
+  permissionDenied: "PermissionDenied"
 };
-
 
 /** ------------------------------------------------------------------------ *
  * @chapter                     CONNECTIVITY                                 *
@@ -749,6 +727,11 @@ AirConsole.prototype.vibrate = function(options) {
  * @param {AirConsole~GetUserMediaConstraint|undefined} constraints - The constraints that were granted (e.g. {audio:
  *   true}). May be undefined if the platform does not include constraint information in the update payload.
  *
+ * @example
+ * airconsole.onUserMediaAccessGranted = function (device_id, constraints) {
+ *    console.info('Controller ' + device_id + ' denied media access for ', JSON.stringify(constraints));
+ * };
+ *
  * @see AirConsole.prototype.getUserMedia
  * @see AirConsole.prototype.onUserMediaAccessDenied
  */
@@ -760,27 +743,18 @@ AirConsole.prototype.onUserMediaAccessGranted = function(device_id, constraints)
  * On the requesting device, the getUserMedia promise will provide the result immediately.
  * @abstract
  * @param {number} device_id - The device_id of the controller.
- * @param {AirConsole.USERMEDIA_ERROR_TYPE} errorType - The type of denial. One of the values from AirConsole.USERMEDIA_ERROR_TYPE.
+ * @param {AirConsole~GetUserMediaConstraint|undefined} constraints - The constraints that were granted (e.g. {audio:
+ *   true}). May be undefined if the platform does not include constraint information in the update payload.
  *
  * @example
- * airconsole.onUserMediaAccessDenied = function (device_id, errorType) {
- *   if (errorType === AirConsole.USERMEDIA_ERROR_TYPE.temporary) {
- *     console.log('Controller ' + device_id + ' temporarily denied media access');
- *     // You could prompt the user on the controller to try again
- *   } else if (errorType === AirConsole.USERMEDIA_ERROR_TYPE.permanent) {
- *     console.log('Controller ' + device_id + ' permanently denied media access');
- *     // Disable features that require microphone access for this controller
- *   } else if (errorType === AirConsole.USERMEDIA_ERROR_TYPE.outdated) {
- *     console.log('Controller ' + device_id + ' has outdated software that does not support media access');
- *     // Inform the user they need to update their device software
- *   }
+ * airconsole.onUserMediaAccessDenied = function (device_id, constraints) {
+*    console.info('Controller ' + device_id + ' denied media access for ', JSON.stringify(constraints));
  * };
  *
- * @see AirConsole.USERMEDIA_ERROR_TYPE
  * @see AirConsole.prototype.getUserMedia
  * @see AirConsole.prototype.onUserMediaAccessGranted
  */
-AirConsole.prototype.onUserMediaAccessDenied = function (device_id, errorType) {};
+AirConsole.prototype.onUserMediaAccessDenied = function (device_id, constraints) {};
 
 /**
  * Module-private storage for pending getUserMedia promise callbacks.
@@ -789,6 +763,13 @@ AirConsole.prototype.onUserMediaAccessDenied = function (device_id, errorType) {
  * @private
  */
 const mediaPermissionCallbacks_ = new WeakMap();
+
+
+const createAirConsoleUserMediaError = (message) => {
+  const error = new Error(message);
+  error.name = "AirConsole.UserMediaError";
+  return error;
+};
 
 /**
  * @typedef {Object} AirConsole~GetUserMediaConstraint
@@ -800,69 +781,54 @@ const mediaPermissionCallbacks_ = new WeakMap();
 /**
  * Requests media permissions (e.g. microphone or camera) for the controller.
  * Can only be called by a controller (not the screen).
- * @param {Object.<AirConsole~GetUserMediaConstraint>} constraints - User Media Request constraints.
- * @return {Promise.<{success: boolean, stream: MediaStream=, errorType: string=, error: Error=}>}
+ * @param {Object<AirConsole~GetUserMediaConstraint>} constraints - User Media Request constraints.
+ * @return {Promise<MediaStream>}>}
  *   The Promise follows the same rejection semantics as the native
  *   {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia MediaDevices.getUserMedia}:
  *   native browser errors (e.g. NotAllowedError, NotFoundError) cause the Promise to reject.
  *   All other conditions (not ready, already pending, timeout, platform denial) resolve with
  *   {success: false, ...} so they can be handled in the .then() callback.
  *
- *   On success: {success: true, stream: <MediaStream>}
- *   On platform denial: {success: false, errorType: <string from AirConsole.USERMEDIA_ERROR_TYPE>}
+ *   On success: {MediaStream}
  *   On other error: {success: false, error: <Error>}
  *
  *   Note: callers are responsible for stopping stream tracks when the stream is no longer needed:
- *   result.stream.getTracks().forEach(function(t) { t.stop(); })
+ *   stream.getTracks().forEach(function(t) { t.stop(); })
  *
  * @example
- * airconsole.getUserMedia({ audio: true }).then(function(result) {
- *   if (result.success) {
- *     console.log('Media access granted', result.stream);
- *   } else if (result.errorType === AirConsole.USERMEDIA_ERROR_TYPE.temporary) {
- *     console.log('User temporarily denied media access');
- *     // Try requesting media access again later, e.g. after a user interaction
- *   } else if (result.errorType === AirConsole.USERMEDIA_ERROR_TYPE.permanent) {
- *     console.log('User permanently denied media access');
- *   } else if (result.errorType === AirConsole.USERMEDIA_ERROR_TYPE.outdated) {
- *     console.log('Device software is too old to support media access');
- *     // Inform the user they need to update their device software
- *   } else if (result.error) {
- *     console.error('Error requesting media access:', result.error);
+ * airconsole.getUserMedia({ audio: true }).then(function(stream) {
+ *   if (stream) {
+ *     console.info('Media access granted', stream);
  *   }
  * }).catch(function (error) {
  *   // Native browser getUserMedia error (e.g. NotAllowedError, NotFoundError, AbortError)
  *   console.error('Native browser media access error:', error);
  * });
  *
- * @see AirConsole.USERMEDIA_ERROR_TYPE
  * @see AirConsole.prototype.onUserMediaAccessGranted
  * @see AirConsole.prototype.onUserMediaAccessDenied
  */
 AirConsole.prototype.getUserMedia = function getUserMedia(constraints) {
+  if (this.device_id === AirConsole.SCREEN) {
+    return Promise.reject(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.notSupportedOnScreen));
+  }
+  if (this.device_id === undefined) {
+    return Promise.reject(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.notReady));
+  }
+  if (this.media_permission_pending_) {
+    return Promise.reject(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.alreadyPending));
+  }
+  if (!constraints || !('audio' in constraints || 'video' in constraints)) {
+    return Promise.reject(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
+  }
+
   var me = this;
   return new Promise(function (resolve, reject) {
-    if (me.device_id === AirConsole.SCREEN) {
-      resolve({ success: false, error: new Error(AirConsole.USERMEDIA_ERROR.notSupportedOnScreen) });
-      return;
-    }
-    if (me.device_id === undefined) {
-      resolve({ success: false, error: new Error(AirConsole.USERMEDIA_ERROR.notReady) });
-      return;
-    }
-    if (me.media_permission_pending_) {
-      resolve({ success: false, error: new Error(AirConsole.USERMEDIA_ERROR.alreadyPending) });
-      return;
-    }
-    if (!constraints || !('audio' in constraints || 'video' in constraints)) {
-      resolve({ success: false, error: new Error(AirConsole.USERMEDIA_ERROR.invalidConstraints) });
-      return;
-    }
     me.media_permission_constraints_ = constraints;
     me.media_permission_pending_ = true;
     mediaPermissionCallbacks_.set(me, { resolve: resolve, reject: reject });
     me.media_permission_timeout_ = setTimeout(function() {
-      me.resolveMediaPermission_({ success: false, error: new Error(AirConsole.USERMEDIA_ERROR.timeout) });
+      me.rejectMediaPermission_(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.timeout));
     }, 30000);
 
     // Send the request to the platform to decide where and how the user media request needs to take place based on
@@ -880,10 +846,10 @@ AirConsole.prototype.cleanUpMediaPermission_ = function cleanUpMediaPermission_(
   mediaPermissionCallbacks_.delete(this);
 }
 
-AirConsole.prototype.resolveMediaPermission_ = function resolveMediaPermission_(result) {
+AirConsole.prototype.resolveMediaPermission_ = function resolveMediaPermission_(stream) {
   const cb = mediaPermissionCallbacks_.get(this);
   this.cleanUpMediaPermission_();
-  if (cb) { cb.resolve(result); }
+  if (cb) { cb.resolve(stream); }
 };
 
 AirConsole.prototype.rejectMediaPermission_ = function rejectMediaPermission_(error) {
@@ -1574,11 +1540,11 @@ AirConsole.prototype.onPostMessage_ = function(event) {
         }
         if (data.device_data._is_userMediaPermission_update) {
           if (data.device_data.userMediaPermission) {
-            const { granted, errorType, constraints } = data.device_data.userMediaPermission;
+            const { granted } = data.device_data.userMediaPermission;
             if (granted) {
-              me.onUserMediaAccessGranted(sender, constraints);
+              me.onUserMediaAccessGranted(sender, me.media_permission_constraints_);
             } else {
-              me.onUserMediaAccessDenied(sender, errorType || AirConsole.USERMEDIA_ERROR_TYPE.temporary);
+              me.onUserMediaAccessDenied(sender, me.media_permission_constraints_);
             }
           }
         }
@@ -1690,18 +1656,6 @@ AirConsole.prototype.onPostMessage_ = function(event) {
     }
 
     if (type === 'userMediaPermissionDenied') {
-      // Validate errorType against the known enum to prevent unexpected values reaching callers.
-      const validErrorTypes = [
-        AirConsole.USERMEDIA_ERROR_TYPE.temporary,
-        AirConsole.USERMEDIA_ERROR_TYPE.permanent,
-        AirConsole.USERMEDIA_ERROR_TYPE.outdated
-      ];
-
-      const rawErrorType = data.data?.errorType;
-      const errorType = rawErrorType && validErrorTypes.indexOf(rawErrorType) !== -1
-        ? rawErrorType
-        : AirConsole.USERMEDIA_ERROR_TYPE.temporary;
-
       // If a browser error was cached (from a local getUserMedia failure that was sent to platform),
       // reject with the original error object to preserve instanceof checks.
       if (me.cachedMediaError_) {
@@ -1709,11 +1663,10 @@ AirConsole.prototype.onPostMessage_ = function(event) {
         me.cachedMediaError_ = null;
         me.rejectMediaPermission_(cachedError);
       } else {
-        me.resolveMediaPermission_({ success: false, errorType });
+        const error = createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.permissionDenied);
+        me.rejectMediaPermission_(error);
       }
     } else if (type === 'userMediaPermissionGranted' || type === 'promptUserMediaPermission') {
-      const userPromptStartTime = performance.now();
-
       navigator.mediaDevices.getUserMedia(me.media_permission_constraints_).then(
         function success(stream) {
           if (!me.media_permission_pending_) {
@@ -1729,22 +1682,16 @@ AirConsole.prototype.onPostMessage_ = function(event) {
           me.sendEvent_('userMediaPermissionGranted', {
             constraints: grantedConstraints,
           });
-          me.resolveMediaPermission_({ success: true, stream: stream });
+          me.resolveMediaPermission_(stream);
         },
         function failure(error) {
           // Native controller: platform already granted permission but stream open failed.
+          // TODO(marc): Is this case still relevant?
           if (type === 'userMediaPermissionGranted') {
-            me.resolveMediaPermission_({ success: false, error });
+            me.rejectMediaPermission_(error);
           } else {
-            if (error instanceof DOMException) {
-              // Web-based controller: browser denied the permission dialog.
-              // Cache the error so we can reject with it when platform echoes back errorType.
-              me.cachedMediaError_ = error;
-            }
-
-            // Always notify the platform regardless of error type so its state machine can recover.
-            const userPromptDuration = performance.now() - userPromptStartTime;
-            me.sendEvent_('userMediaPermissionDenied', { errorType: error.name, userPromptDuration });
+            me.cachedMediaError_ = error;
+            me.sendEvent_('userMediaPermissionDenied', { errorType: error.name });
           }
         }
       );

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -770,6 +770,9 @@ AirConsole.prototype.onUserMediaAccessGranted = function(device_id, constraints)
  *   } else if (errorType === AirConsole.USERMEDIA_ERROR_TYPE.permanent) {
  *     console.log('Controller ' + device_id + ' permanently denied media access');
  *     // Disable features that require microphone access for this controller
+ *   } else if (errorType === AirConsole.USERMEDIA_ERROR_TYPE.outdated) {
+ *     console.log('Controller ' + device_id + ' has outdated software that does not support media access');
+ *     // Inform the user they need to update their device software
  *   }
  * };
  *
@@ -821,6 +824,9 @@ const mediaPermissionCallbacks_ = new WeakMap();
  *     // Try requesting media access again later, e.g. after a user interaction
  *   } else if (result.errorType === AirConsole.USERMEDIA_ERROR_TYPE.permanent) {
  *     console.log('User permanently denied media access');
+ *   } else if (result.errorType === AirConsole.USERMEDIA_ERROR_TYPE.outdated) {
+ *     console.log('Device software is too old to support media access');
+ *     // Inform the user they need to update their device software
  *   } else if (result.error) {
  *     console.error('Error requesting media access:', result.error);
  *   }

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -1736,16 +1736,15 @@ AirConsole.prototype.onPostMessage_ = function(event) {
           if (type === 'userMediaPermissionGranted') {
             me.resolveMediaPermission_({ success: false, error });
           } else {
-            if (type === 'userMediaPermissionDenied') {
-              // Always notify the platform regardless of error type so its state machine can recover.
-              const userPromptDuration = performance.now() - userPromptStartTime;
-              me.sendEvent_('userMediaPermissionDenied', { errorType: error.name, userPromptDuration });
-            } else if (error instanceof DOMException) {
+            if (error instanceof DOMException) {
               // Web-based controller: browser denied the permission dialog.
               // Cache the error so we can reject with it when platform echoes back errorType.
               me.cachedMediaError_ = error;
-              me.sendEvent_('userMediaPermissionDenied', { errorType: error.name });
             }
+
+            // Always notify the platform regardless of error type so its state machine can recover.
+            const userPromptDuration = performance.now() - userPromptStartTime;
+            me.sendEvent_('userMediaPermissionDenied', { errorType: error.name, userPromptDuration });
           }
         }
       );

--- a/beta/airconsole-1.11.0.js
+++ b/beta/airconsole-1.11.0.js
@@ -140,8 +140,9 @@ AirConsole.VIBRATE = {
  * @property {string} notSupportedOnScreen - getUserMedia cannot be called on the screen device.
  * @property {string} notReady - AirConsole is not yet ready (device_id not assigned).
  * @property {string} alreadyPending - A getUserMedia request is already in progress.
- * @property {string} invalidConstraints - Constraints must include at least audio or video.
+ * @property {string} invalidConstraints - Constraints are missing, contain unsupported options (e.g. video), or do not include audio.
  * @property {string} timeout - The permission request timed out waiting for a user response.
+ * @property {string} permissionDenied - The user explicitly denied the media permission request.
  *
  * @see AirConsole.prototype.getUserMedia
  */
@@ -153,6 +154,21 @@ AirConsole.USERMEDIA_ERROR = {
   timeout: "Timeout",
   permissionDenied: "PermissionDenied"
 };
+
+/**
+ * Represents an error specific to user media operations within the AirConsole platform.
+ * This error is thrown when there is an issue related to accessing or managing user media.
+ *
+ * @extends {Error}
+ *
+ * @param {AirConsole.USERMEDIA_ERROR} message - The message is of type AirConsole.USERMEDIA_ERROR.
+ */
+class AirConsoleUserMediaError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'AirConsole.UserMediaError';
+  }
+}
 
 /** ------------------------------------------------------------------------ *
  * @chapter                     CONNECTIVITY                                 *
@@ -760,62 +776,70 @@ AirConsole.prototype.onUserMediaAccessDenied = function (device_id) {};
  */
 const mediaPermissionCallbacks_ = new WeakMap();
 
-
-const createAirConsoleUserMediaError = (message) => {
-  const error = new Error(message);
-  error.name = "AirConsole.UserMediaError";
-  return error;
-};
-
 /**
  * @typedef {Object} AirConsole~GetUserMediaConstraint
- * @property {boolean} audio - Whether to request audio permissions.
- * @property {boolean | object} video - True, to use default camera video stream or specific object following the
- *   {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia getUserMedia constraints}.
+ * @property {boolean} audio - Whether to request microphone permissions. Must be provided; video is not supported.
  */
 
 /**
- * Requests media permissions (e.g. microphone or camera) for the controller.
- * Can only be called by a controller (not the screen).
- * @param {Object<AirConsole~GetUserMediaConstraint>} constraints - User Media Request constraints.
- * @return {Promise<MediaStream>}>}
- *   The Promise follows the same rejection semantics as the native
- *   {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia MediaDevices.getUserMedia}:
- *   native browser errors (e.g. NotAllowedError, NotFoundError) cause the Promise to reject.
- *   All other conditions (not ready, already pending, timeout, platform denial) resolve with
- *   {success: false, ...} so they can be handled in the .then() callback.
+ * Requests microphone permissions for the controller device.
+ * Can only be called by a controller (not the screen). Video constraints are not supported.
  *
- *   On success: {MediaStream}
- *   On other error: {success: false, error: <Error>}
+ * @param {AirConsole~GetUserMediaConstraint} constraints - Media constraints. Must include `audio: true`.
+ *   Video constraints are not supported and will cause the promise to reject with
+ *   {@link AirConsole.USERMEDIA_ERROR}.invalidConstraints.
+ * @return {Promise<MediaStream>} Resolves with the granted {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaStream MediaStream}
+ *   on success. Rejects with {AirConsoleUserMediaError} (see {@link AirConsole.USERMEDIA_ERROR}) for
+ *   AirConsole-specific failures, or with a native
+ *   {@link https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia DOMException}
+ *   (e.g. `NotAllowedError`, `NotFoundError`) when the browser itself denies the request.
  *
  *   Note: callers are responsible for stopping stream tracks when the stream is no longer needed:
- *   stream.getTracks().forEach(function(t) { t.stop(); })
+ *   `stream.getTracks().forEach(function(t) { t.stop(); })`
  *
  * @example
  * airconsole.getUserMedia({ audio: true }).then(function(stream) {
- *   if (stream) {
- *     console.info('Media access granted', stream);
+ *   console.info('Media access granted', stream);
+ *   // Remember to stop tracks when done:
+ *   // stream.getTracks().forEach(function(t) { t.stop(); });
+ * }).catch(function(error) {
+ *   if (error.name === 'AirConsole.UserMediaError') {
+ *     // AirConsole-specific error, see AirConsole.USERMEDIA_ERROR for possible values
+ *     console.error('AirConsole media error:', error.message);
+ *   } else {
+ *     // Native browser error (e.g. NotAllowedError, NotFoundError, AbortError)
+ *     console.error('Browser media access error:', error);
  *   }
- * }).catch(function (error) {
- *   // Native browser getUserMedia error (e.g. NotAllowedError, NotFoundError, AbortError)
- *   console.error('Native browser media access error:', error);
  * });
  *
+ * @see AirConsole.USERMEDIA_ERROR
  * @see AirConsole.prototype.onUserMediaAccessGranted
  * @see AirConsole.prototype.onUserMediaAccessDenied
  */
 AirConsole.prototype.getUserMedia = function getUserMedia(constraints) {
   if (this.device_id === AirConsole.SCREEN) {
-    return Promise.reject(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.notSupportedOnScreen));
+    console.error(`AirConsole.getUserMedia not supported on screen`);
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.notSupportedOnScreen));
   }
   if (this.device_id === undefined) {
-    return Promise.reject(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.notReady));
+    console.error(`AirConsole.getUserMedia requires device to be initialized`);
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.notReady));
   }
   if (this.mediaPermissionPending_) {
-    return Promise.reject(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.alreadyPending));
+    console.error(`AirConsole.getUserMedia already has a pending request`);
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.alreadyPending));
   }
-  if (!constraints || !('audio' in constraints || 'video' in constraints)) {
-    return Promise.reject(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
+  if (!constraints) {
+    console.error(`AirConsole.getUserMedia requires constraints to be provided`);
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
+  }
+  if (!!constraints.video) {
+    console.error(`AirConsole.getUserMedia does not support video, please remove video from the constraints`);
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
+  }
+  if (!('audio' in constraints)) {
+    console.error(`AirConsole.getUserMedia requires audio constraints to be provided`);
+    return Promise.reject(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.invalidConstraints));
   }
 
   var me = this;
@@ -824,7 +848,7 @@ AirConsole.prototype.getUserMedia = function getUserMedia(constraints) {
     me.mediaPermissionPending_ = true;
     mediaPermissionCallbacks_.set(me, { resolve: resolve, reject: reject });
     me.mediaPermissionTimeout_ = setTimeout(function() {
-      me.rejectMediaPermission_(createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.timeout));
+      me.rejectMediaPermission_(new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.timeout));
     }, 30000);
 
     // Send the request to the platform to decide where and how the user media request needs to take place based on
@@ -1659,7 +1683,7 @@ AirConsole.prototype.onPostMessage_ = function(event) {
         me.cachedMediaError_ = null;
         me.rejectMediaPermission_(cachedError);
       } else {
-        const error = createAirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.permissionDenied);
+        const error = new AirConsoleUserMediaError(AirConsole.USERMEDIA_ERROR.permissionDenied);
         me.rejectMediaPermission_(error);
       }
     } else if (type === 'userMediaPermissionGranted' || type === 'promptUserMediaPermission') {

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -66,11 +66,11 @@ function testUserMediaPermissions() {
 
     // Group 1: Early synchronous rejections
 
-    it('Should reject with AirConsole.USERMEDIA_ERROR.notSupportedOnScreen when device_id is SCREEN', function(done) {
+    it('Should reject with AirConsole.USER_MEDIA_ERROR_TYPE.notSupportedOnScreen when device_id is SCREEN', function(done) {
       airconsole.device_id = AirConsole.SCREEN;
       airconsole.getUserMedia({ audio: true }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
-        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.notSupportedOnScreen);
+        expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.notSupportedOnScreen);
         done();
       });
     });
@@ -79,64 +79,64 @@ function testUserMediaPermissions() {
       airconsole.device_id = undefined;
       airconsole.getUserMedia({ audio: true }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
-        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.notReady);
+        expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.notReady);
         done();
       });
     });
 
-    it('Should reject with AirConsole.USERMEDIA_ERROR.alreadyPending when a request is already in progress', function(done) {
+    it('Should reject with AirConsole.USER_MEDIA_ERROR_TYPE.alreadyPending when a request is already in progress', function(done) {
       airconsole.mediaPermissionPending_ = true;
       airconsole.getUserMedia({ audio: true }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
-        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.alreadyPending);
+        expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.alreadyPending);
         done();
       });
     });
 
-    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints when constraints are null', function(done) {
+    it('Should reject with AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints when constraints are null', function(done) {
       airconsole.getUserMedia(null).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
-        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+        expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints);
         done();
       });
     });
 
-    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints with constraint { audio: true, video: true }', function(done) {
+    it('Should reject with AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints with constraint { audio: true, video: true }', function(done) {
       airconsole.getUserMedia({ video: true }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
-        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+        expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints);
         done();
       });
     });
 
-    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints with constraint { video: true }', function(done) {
+    it('Should reject with AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints with constraint { video: true }', function(done) {
       airconsole.getUserMedia({ video: true }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
-        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+        expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints);
         done();
       });
     });
 
-    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints with constraint { audio: false }', function(done) {
+    it('Should reject with AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints with constraint { audio: false }', function(done) {
       airconsole.getUserMedia({ audio: false }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
-        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+        expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints);
         done();
       });
     });
 
-    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints with constraint { video: { width: 1280, height: 720 } }', function(done) {
+    it('Should reject with AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints with constraint { video: { width: 1280, height: 720 } }', function(done) {
       airconsole.getUserMedia({ video: { width: 1280, height: 720 } }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
-        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+        expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints);
         done();
       });
     });
 
-    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints when constraints have no audio property', function(done) {
+    it('Should reject with AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints when constraints have no audio property', function(done) {
       airconsole.getUserMedia({ foo: true }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
-        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+        expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.invalidConstraints);
         done();
       });
     });
@@ -151,7 +151,7 @@ function testUserMediaPermissions() {
 
     // Group 2: resolveMediaPermission_ via platform event responses
 
-    it('Should reject AirConsole.USERMEDIA_ERROR.permissionDenied on userMediaPermissionDenied', function(done) {
+    it('Should reject AirConsole.USER_MEDIA_ERROR_TYPE.permissionDenied on userMediaPermissionDenied', function(done) {
       airconsole.getUserMedia({ audio: true }).catch(function(error) {
         expect(error.name).toBe('AirConsole.UserMediaError');
         expect(error.message).toBe('PermissionDenied');
@@ -215,10 +215,10 @@ function testUserMediaPermissions() {
 
     // Group 3: Timeout
 
-    it('Should reject with AirConsole.USERMEDIA_ERROR.timeout after 30000ms', function(done) {
+    it('Should reject with AirConsole.USER_MEDIA_ERROR_TYPE.timeout after 30000ms', function(done) {
       airconsole.getUserMedia({ audio: true }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
-        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.timeout);
+        expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.timeout);
         done();
       });
       jasmine.clock().tick(30001);
@@ -588,7 +588,7 @@ function testUserMediaPermissions() {
       spyOn(airconsole, 'sendEvent_');
       airconsole.getUserMedia({ audio: true }).catch(function (error) {
         expect(error.name).toBe('AirConsole.UserMediaError');
-        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.timeout);
+        expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.timeout);
         done();
       });
       airconsole.destroy();

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -85,7 +85,7 @@ function testUserMediaPermissions() {
     });
 
     it('Should reject with AirConsole.USERMEDIA_ERROR.alreadyPending when a request is already in progress', function(done) {
-      airconsole.media_permission_pending_ = true;
+      airconsole.mediaPermissionPending_ = true;
       airconsole.getUserMedia({ audio: true }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
         expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.alreadyPending);
@@ -160,19 +160,19 @@ function testUserMediaPermissions() {
       dispatchCustomMessageEvent({ action: 'event', type: 'promptUserMediaPermission' });
     });
 
-    it('Should clear media_permission_pending_ after resolution', function(done) {
+    it('Should clear mediaPermissionPending_ after resolution', function(done) {
       const fakeStream = makeFakeStream();
       spyOn(navigator.mediaDevices, 'getUserMedia').and.returnValue(Promise.resolve(fakeStream));
       airconsole.getUserMedia({ audio: true }).then(function() {
-        expect(airconsole.media_permission_pending_).toBe(false);
+        expect(airconsole.mediaPermissionPending_).toBe(false);
         done();
       });
       dispatchCustomMessageEvent({ action: 'event', type: 'userMediaPermissionGranted' });
     });
 
-    it('Should clear media_permission_pending_ when userMediaPermissionDenied is received', function (done) {
+    it('Should clear mediaPermissionPending_ when userMediaPermissionDenied is received', function (done) {
       airconsole.getUserMedia({ audio: true }).catch(function () {
-        expect(airconsole.media_permission_pending_).toBe(false);
+        expect(airconsole.mediaPermissionPending_).toBe(false);
         done();
       });
       dispatchCustomMessageEvent({
@@ -292,10 +292,10 @@ function testUserMediaPermissions() {
         promptUserMediaPermission();
       });
 
-      it('Should clear media_permission_pending_ after rejection', function (done) {
+      it('Should clear mediaPermissionPending_ after rejection', function (done) {
         spyGetUserMediaReject(makeNotAllowedError());
         airconsole.getUserMedia({ audio: true }).catch(function () {
-          expect(airconsole.media_permission_pending_).toBe(false);
+          expect(airconsole.mediaPermissionPending_).toBe(false);
           done();
         });
         promptUserMediaPermission();
@@ -384,7 +384,7 @@ function testUserMediaPermissions() {
     it('Should call onUserMediaAccessDenied(device_id, temporary) when granted=false', function () {
       spyOn(airconsole, 'onUserMediaAccessDenied');
       const constraints = { audio: true };
-      airconsole.media_permission_constraints_ = constraints;
+      airconsole.mediaPermissionConstraints_ = constraints;
       broadcastPermissionUpdate({
         granted: false
       });
@@ -532,17 +532,17 @@ function testUserMediaPermissions() {
       );
     });
 
-    it('Should clear a pending media_permission_timeout_ on destroy', function () {
+    it('Should clear a pending mediaPermissionTimeout_ on destroy', function () {
       jasmine.clock().install();
       spyOn(navigator.mediaDevices, 'getUserMedia').and.returnValue(
         new Promise(function () {}),
       );
       spyOn(airconsole, 'sendEvent_');
       airconsole.getUserMedia({ audio: true });
-      expect(airconsole.media_permission_timeout_).toBeDefined();
+      expect(airconsole.mediaPermissionTimeout_).toBeDefined();
 
       airconsole.destroy();
-      expect(airconsole.media_permission_timeout_).toBeNull();
+      expect(airconsole.mediaPermissionTimeout_).toBeNull();
       jasmine.clock().uninstall();
     });
 

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -215,13 +215,13 @@ function testUserMediaPermissions() {
 
     // Group 3: Timeout
 
-    it('Should reject with AirConsole.USER_MEDIA_ERROR_TYPE.timeout after 30000ms', function(done) {
+    it('Should reject with AirConsole.USER_MEDIA_ERROR_TYPE.timeout after 45000ms', function(done) {
       airconsole.getUserMedia({ audio: true }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
         expect(error.message).toBe(AirConsole.USER_MEDIA_ERROR_TYPE.timeout);
         done();
       });
-      jasmine.clock().tick(30001);
+      jasmine.clock().tick(45001);
     });
   });
 
@@ -285,10 +285,7 @@ function testUserMediaPermissions() {
           .catch(function(error) {
             expect(error).toBe(domException);
             expect(error).toBeInstanceOf(DOMException);
-            expect(airconsole.sendEvent_).toHaveBeenCalledWith(
-              'userMediaPermissionDenied',
-              jasmine.objectContaining({ errorType: domException.name })
-            );
+            expect(airconsole.sendEvent_).toHaveBeenCalledWith('userMediaPermissionDenied');
             done();
           });
         promptUserMediaPermission();
@@ -303,10 +300,7 @@ function testUserMediaPermissions() {
         const domException = makeNotAllowedError();
         spyGetUserMediaReject(domException);
         airconsole.getUserMedia({ audio: true }).catch(function () {
-          expect(airconsole.sendEvent_).toHaveBeenCalledWith(
-            'userMediaPermissionDenied',
-              jasmine.objectContaining({ errorType: domException.name })
-          );
+          expect(airconsole.sendEvent_).toHaveBeenCalledWith('userMediaPermissionDenied');
           done();
         });
         promptUserMediaPermission();
@@ -482,7 +476,7 @@ function testUserMediaPermissions() {
     beforeEach(function () {
       initAirConsoleAsController();
       // Simulate the platform echo for denial events.
-      // In the new flow, the controller caches the error locally. Platform echoes back with errorType.
+      // In the new flow, the controller caches the error locally.
       spyOn(airconsole, 'sendEvent_').and.callFake(function (eventType, eventData) {
         // Pipe the event back
         dispatchCustomMessageEvent({

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -671,7 +671,7 @@ function testUserMediaPermissions() {
       });
 
       dispatchCustomMessageEvent({ action: 'event', type: 'promptUserMediaPermission' });
-      jasmine.clock().tick(30001);
+      jasmine.clock().tick(45001);
     });
 
     it('Should not set cachedMediaError_ when browser failure arrives after timeout', function (done) {

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -30,8 +30,7 @@ function testUserMediaPermissions() {
   }
 
   function makeNotAllowedError() {
-    const err = new Error('Permission denied by user');
-    err.name = 'NotAllowedError';
+    const err = new DOMException('Permission denied by user', 'NotAllowedError');
     return err;
   }
 
@@ -40,6 +39,18 @@ function testUserMediaPermissions() {
     err.name = 'NotFoundError';
     return err;
   }
+
+  // --- Group 0: Constants ---
+
+  describe('USERMEDIA_ERROR_TYPE constant', function () {
+    it('should have namespaced values for temporary, permanent, and outdated', function () {
+      expect(AirConsole.USERMEDIA_ERROR_TYPE).toEqual({
+        temporary: 'AirConsole.temporary',
+        permanent: 'AirConsole.permanent',
+        outdated: 'AirConsole.outdated',
+      });
+    });
+  });
 
   // --- Group 1–3: getUserMedia() return value / promise resolution ---
   // Uses jasmine.clock() for the timeout test
@@ -119,27 +130,39 @@ function testUserMediaPermissions() {
 
     // Group 2: resolveMediaPermission_ via platform event responses
 
-    it('Should resolve {success:false, reason:temporary} on userMediaPermissionDenied', function(done) {
+    it('Should resolve {success:false, errorType:AirConsole.temporary} on userMediaPermissionDenied', function(done) {
       airconsole.getUserMedia({ audio: true }).then(function(result) {
         expect(result.success).toBe(false);
-        expect(result.reason).toBe('temporary');
+        expect(result.errorType).toBe('AirConsole.temporary');
         done();
       });
       dispatchCustomMessageEvent({
         action: 'event', type: 'userMediaPermissionDenied',
-        data: { reason: AirConsole.MEDIA_PERMISSION_DENIED.temporary }
+        data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.temporary }
       });
     });
 
-    it('Should resolve {success:false, reason:permanent} on userMediaPermissionDenied with permanent reason', function(done) {
+    it('Should resolve {success:false, errorType:AirConsole.permanent} on userMediaPermissionDenied with permanent', function(done) {
       airconsole.getUserMedia({ audio: true }).then(function(result) {
         expect(result.success).toBe(false);
-        expect(result.reason).toBe('permanent');
+        expect(result.errorType).toBe('AirConsole.permanent');
         done();
       });
       dispatchCustomMessageEvent({
         action: 'event', type: 'userMediaPermissionDenied',
-        data: { reason: AirConsole.MEDIA_PERMISSION_DENIED.permanent }
+        data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.permanent }
+      });
+    });
+
+    it('Should resolve {success:false, errorType:AirConsole.outdated} on userMediaPermissionDenied with outdated', function(done) {
+      airconsole.getUserMedia({ audio: true }).then(function(result) {
+        expect(result.success).toBe(false);
+        expect(result.errorType).toBe('AirConsole.outdated');
+        done();
+      });
+      dispatchCustomMessageEvent({
+        action: 'event', type: 'userMediaPermissionDenied',
+        data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.outdated }
       });
     });
 
@@ -203,16 +226,16 @@ function testUserMediaPermissions() {
   describe('media permission flows', function () {
     beforeEach(function () {
       initAirConsoleAsController();
-      // Spy on sendEvent_ and simulate the platform echo for denial events that carry an error.
-      // In the new flow the controller notifies the platform of the denial (with the error object)
-      // and the platform echoes back a userMediaPermissionDenied event containing the error,
-      // which triggers rejectMediaPermission_ locally.
+      // Spy on sendEvent_ and simulate the platform echo for denial events.
+      // In the new flow the controller caches the error locally, notifies the platform
+      // (with userPromptDuration only), and the platform echoes back a userMediaPermissionDenied
+      // event containing errorType. The implementation then rejects with the cached error.
       spyOn(airconsole, 'sendEvent_').and.callFake(function (eventType, eventData) {
-        if (eventType === 'userMediaPermissionDenied' && eventData && eventData.error) {
+        if (eventType === 'userMediaPermissionDenied' && eventData && eventData.userPromptDuration !== undefined) {
           dispatchCustomMessageEvent({
             action: 'event',
             type: 'userMediaPermissionDenied',
-            data: { error: eventData.error },
+            data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.temporary },
           });
         }
       });
@@ -230,12 +253,12 @@ function testUserMediaPermissions() {
       spyOn(navigator.mediaDevices, 'getUserMedia').and.returnValue(Promise.resolve(stream));
     }
 
-    // Dispatches a userMediaPermissionDenied event with an optional reason
-    // (defaults to temporary, matching the most common test scenario).
-    function dispatchDenied(reason) {
+    // Dispatches a userMediaPermissionDenied event with an optional errorType
+    // (defaults to AirConsole.temporary, matching the most common test scenario).
+    function dispatchDenied(errorType) {
       dispatchCustomMessageEvent({
         action: 'event', type: 'userMediaPermissionDenied',
-        data: { reason: reason || AirConsole.MEDIA_PERMISSION_DENIED.temporary }
+        data: { errorType: errorType || AirConsole.USERMEDIA_ERROR_TYPE.temporary }
       });
     }
 
@@ -249,7 +272,7 @@ function testUserMediaPermissions() {
           .then(function (result) {
             resolutionCount++;
             expect(result.success).toBe(false);
-            expect(result.reason).toBe('temporary');
+            expect(result.errorType).toBe('AirConsole.temporary');
           })
           .catch(function () {
             fail('Should not reject after resolution');
@@ -263,14 +286,15 @@ function testUserMediaPermissions() {
         dispatchDenied();
       });
 
-      it('Should reject with a browser-style AbortError when browser getUserMedia is aborted', function (done) {
-        const browserError = new Error('The operation was aborted.');
-        browserError.name = 'AbortError';
-        spyGetUserMediaReject(browserError);
+      it('Should reject with a DOMException when browser getUserMedia is aborted', function (done) {
+        const domException = new DOMException('DOM Abort Test', 'AbortError');
+        spyGetUserMediaReject(domException);
         airconsole.getUserMedia({ audio: true }).catch(function (error) {
+          expect(error).toBe(domException);
+          expect(error).toBeInstanceOf(DOMException);
           expect(airconsole.sendEvent_).toHaveBeenCalledWith(
             'userMediaPermissionDenied',
-            jasmine.objectContaining({ error: browserError }),
+            jasmine.objectContaining({ userPromptDuration: jasmine.any(Number) }),
           );
           done();
         });
@@ -280,7 +304,8 @@ function testUserMediaPermissions() {
 
     // --- Group 5: promptUserMediaPermission + NotAllowedError ---
     // Platform sends 'promptUserMediaPermission'; browser getUserMedia fails with NotAllowedError.
-    // Implementation fires sendEvent_('userMediaPermissionDenied') then rejects the promise.
+    // Implementation caches the error, fires sendEvent_('userMediaPermissionDenied') with
+    // userPromptDuration, then when platform echoes back errorType, rejects with cached error.
 
     describe('promptUserMediaPermission NotAllowedError rejection flow', function () {
       it('Should fire sendEvent_(userMediaPermissionDenied) with userPromptDuration', function (done) {
@@ -297,11 +322,12 @@ function testUserMediaPermissions() {
         promptUserMediaPermission();
       });
 
-      it('Should reject the promise with the NotAllowedError', function (done) {
+      it('Should reject the promise with the cached NotAllowedError', function (done) {
         const notAllowedError = makeNotAllowedError();
         spyGetUserMediaReject(notAllowedError);
         airconsole.getUserMedia({ audio: true }).catch(function (error) {
           expect(error).toBe(notAllowedError);
+          expect(error).toBeInstanceOf(DOMException);
           expect(error.name).toBe('NotAllowedError');
           done();
         });
@@ -399,36 +425,36 @@ function testUserMediaPermissions() {
       );
     });
 
-    it('Should call onUserMediaAccessDenied(device_id, temporary) when granted=false with temporary reason', function () {
+    it('Should call onUserMediaAccessDenied(device_id, temporary) when granted=false with temporary errorType', function () {
       spyOn(airconsole, 'onUserMediaAccessDenied');
       broadcastPermissionUpdate({
         granted: false,
-        reason: AirConsole.MEDIA_PERMISSION_DENIED.temporary,
+        errorType: AirConsole.USERMEDIA_ERROR_TYPE.temporary,
       });
       expect(airconsole.onUserMediaAccessDenied).toHaveBeenCalledWith(
         DEVICE_ID,
-        AirConsole.MEDIA_PERMISSION_DENIED.temporary,
+        AirConsole.USERMEDIA_ERROR_TYPE.temporary,
       );
     });
 
-    it('Should call onUserMediaAccessDenied(device_id, permanent) when granted=false with permanent reason', function () {
+    it('Should call onUserMediaAccessDenied(device_id, permanent) when granted=false with permanent errorType', function () {
       spyOn(airconsole, 'onUserMediaAccessDenied');
       broadcastPermissionUpdate({
         granted: false,
-        reason: AirConsole.MEDIA_PERMISSION_DENIED.permanent,
+        errorType: AirConsole.USERMEDIA_ERROR_TYPE.permanent,
       });
       expect(airconsole.onUserMediaAccessDenied).toHaveBeenCalledWith(
         DEVICE_ID,
-        AirConsole.MEDIA_PERMISSION_DENIED.permanent,
+        AirConsole.USERMEDIA_ERROR_TYPE.permanent,
       );
     });
 
-    it('Should default reason to temporary when granted=false but no reason field', function () {
+    it('Should default errorType to temporary when granted=false but no errorType field', function () {
       spyOn(airconsole, 'onUserMediaAccessDenied');
       broadcastPermissionUpdate({ granted: false });
       expect(airconsole.onUserMediaAccessDenied).toHaveBeenCalledWith(
         DEVICE_ID,
-        AirConsole.MEDIA_PERMISSION_DENIED.temporary,
+        AirConsole.USERMEDIA_ERROR_TYPE.temporary,
       );
     });
 
@@ -492,13 +518,15 @@ function testUserMediaPermissions() {
   describe('media permission flows', function () {
     beforeEach(function () {
       initAirConsoleAsController();
-      // Simulate the platform echo for denial events carrying an error (see first block for rationale).
+      // Simulate the platform echo for denial events.
+      // In the new flow, the controller caches the error locally and sends userPromptDuration
+      // to the platform. Platform echoes back with errorType.
       spyOn(airconsole, 'sendEvent_').and.callFake(function (eventType, eventData) {
-        if (eventType === 'userMediaPermissionDenied' && eventData && eventData.error) {
+        if (eventType === 'userMediaPermissionDenied' && eventData && eventData.userPromptDuration !== undefined) {
           dispatchCustomMessageEvent({
             action: 'event',
             type: 'userMediaPermissionDenied',
-            data: { error: eventData.error },
+            data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.temporary },
           });
         }
       });
@@ -512,12 +540,12 @@ function testUserMediaPermissions() {
       });
     }
 
-    function dispatchDenied(reason) {
+    function dispatchDenied(errorType) {
       dispatchCustomMessageEvent({
         action: 'event',
         type: 'userMediaPermissionDenied',
         data: {
-          reason: reason || AirConsole.MEDIA_PERMISSION_DENIED.temporary,
+          errorType: errorType || AirConsole.USERMEDIA_ERROR_TYPE.temporary,
         },
       });
     }
@@ -540,36 +568,31 @@ function testUserMediaPermissions() {
       });
     });
 
-    // --- Group 9b: platform echoes userMediaPermissionDenied with an error object ---
+    // --- Group 9b: platform-only userMediaPermissionDenied with errorType ---
 
-    describe('platform-initiated userMediaPermissionDenied with error', function () {
-      it('Should reject the promise with the error when platform sends an AbortError', function (done) {
-        var abortError = new Error('The operation was aborted.');
-        abortError.name = 'AbortError';
-        airconsole.getUserMedia({ audio: true }).catch(function (error) {
-          expect(error).toBe(abortError);
-          expect(error.name).toBe('AbortError');
-          expect(error.message).toBe('The operation was aborted.');
+    describe('platform-initiated userMediaPermissionDenied with errorType', function () {
+      it('Should resolve {success:false, errorType} when platform sends errorType without cached error', function (done) {
+        airconsole.getUserMedia({ audio: true }).then(function (result) {
+          expect(result.success).toBe(false);
+          expect(result.errorType).toBe(AirConsole.USERMEDIA_ERROR_TYPE.permanent);
           done();
         });
         dispatchCustomMessageEvent({
           action: 'event',
           type: 'userMediaPermissionDenied',
-          data: { error: abortError },
+          data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.permanent },
         });
       });
 
-      it('Should clear media_permission_pending_ when platform sends error', function (done) {
-        var abortError = new Error('The operation was aborted.');
-        abortError.name = 'AbortError';
-        airconsole.getUserMedia({ audio: true }).catch(function () {
+      it('Should clear media_permission_pending_ when platform sends errorType', function (done) {
+        airconsole.getUserMedia({ audio: true }).then(function () {
           expect(airconsole.media_permission_pending_).toBe(false);
           done();
         });
         dispatchCustomMessageEvent({
           action: 'event',
           type: 'userMediaPermissionDenied',
-          data: { error: abortError },
+          data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.permanent },
         });
       });
     });
@@ -577,11 +600,11 @@ function testUserMediaPermissions() {
     // --- Group 10: userMediaPermissionDenied with missing data field ---
 
     describe('userMediaPermissionDenied with missing data', function () {
-      it('Should default reason to temporary when data field is absent', function (done) {
+      it('Should default errorType to temporary when data field is absent', function (done) {
         airconsole.getUserMedia({ audio: true }).then(function (result) {
           expect(result.success).toBe(false);
-          expect(result.reason).toBe(
-            AirConsole.MEDIA_PERMISSION_DENIED.temporary,
+          expect(result.errorType).toBe(
+            AirConsole.USERMEDIA_ERROR_TYPE.temporary,
           );
           done();
         });

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -29,7 +29,8 @@ function testUserMediaPermissions() {
     return {
       getAudioTracks: function() {
         return [{}];
-      }, getTracks: function() {
+      },
+      getTracks: function() {
         return [{
           stop: () => {
           }
@@ -48,18 +49,6 @@ function testUserMediaPermissions() {
     return err;
   }
 
-  // --- Group 0: Constants ---
-
-  describe('USERMEDIA_ERROR_TYPE constant', function () {
-    it('should have namespaced values for temporary, permanent, and outdated', function () {
-      expect(AirConsole.USERMEDIA_ERROR_TYPE).toEqual({
-        temporary: 'AirConsole.temporary',
-        permanent: 'AirConsole.permanent',
-        outdated: 'AirConsole.outdated',
-      });
-    });
-  });
-
   // --- Group 1–3: getUserMedia() return value / promise resolution ---
   // Uses jasmine.clock() for the timeout test
 
@@ -77,53 +66,45 @@ function testUserMediaPermissions() {
 
     // Group 1: Early synchronous rejections
 
-    it('Should resolve {success:false} when device_id is SCREEN', function(done) {
+    it('Should reject with AirConsole.USERMEDIA_ERROR.notSupportedOnScreen when device_id is SCREEN', function(done) {
       airconsole.device_id = AirConsole.SCREEN;
-      airconsole.getUserMedia({ audio: true }).then(function(result) {
-        expect(result.success).toBe(false);
-        expect(result.error.message).toBe(AirConsole.USERMEDIA_ERROR.notSupportedOnScreen);
+      airconsole.getUserMedia({ audio: true }).catch(function(error) {
+        expect(error.name).toBe("AirConsole.UserMediaError");
+        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.notSupportedOnScreen);
         done();
       });
     });
 
-    it('Should resolve {success:false} when device_id is undefined', function(done) {
+    it('Should reject when device_id is undefined', function(done) {
       airconsole.device_id = undefined;
-      airconsole.getUserMedia({ audio: true }).then(function(result) {
-        expect(result.success).toBe(false);
-        expect(result.error.message).toBe(AirConsole.USERMEDIA_ERROR.notReady);
+      airconsole.getUserMedia({ audio: true }).catch(function(error) {
+        expect(error.name).toBe("AirConsole.UserMediaError");
+        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.notReady);
         done();
       });
     });
 
-    it('Should resolve {success:false} when a request is already in progress', function(done) {
+    it('Should reject with AirConsole.USERMEDIA_ERROR.alreadyPending when a request is already in progress', function(done) {
       airconsole.media_permission_pending_ = true;
-      airconsole.getUserMedia({ audio: true }).then(function(result) {
-        expect(result.success).toBe(false);
-        expect(result.error.message).toBe(AirConsole.USERMEDIA_ERROR.alreadyPending);
+      airconsole.getUserMedia({ audio: true }).catch(function(error) {
+        expect(error.name).toBe("AirConsole.UserMediaError");
+        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.alreadyPending);
         done();
       });
     });
 
-    it('Should resolve {success:false} when constraints are null', function(done) {
-      airconsole.getUserMedia(null).then(function(result) {
-        expect(result.success).toBe(false);
-        expect(result.error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints when constraints are null', function(done) {
+      airconsole.getUserMedia(null).catch(function(error) {
+        expect(error.name).toBe("AirConsole.UserMediaError");
+        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
         done();
       });
     });
 
-    it('Should resolve {success:false} when constraints are empty', function(done) {
-      airconsole.getUserMedia({}).then(function(result) {
-        expect(result.success).toBe(false);
-        expect(result.error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
-        done();
-      });
-    });
-
-    it('Should resolve {success:false} when constraints have no audio or video property', function(done) {
-      airconsole.getUserMedia({ foo: true }).then(function(result) {
-        expect(result.success).toBe(false);
-        expect(result.error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints when constraints have no audio or video property', function(done) {
+      airconsole.getUserMedia({ foo: true }).catch(function(error) {
+        expect(error.name).toBe("AirConsole.UserMediaError");
+        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
         done();
       });
     });
@@ -138,70 +119,42 @@ function testUserMediaPermissions() {
 
     // Group 2: resolveMediaPermission_ via platform event responses
 
-    it('Should resolve {success:false, errorType:AirConsole.temporary} on userMediaPermissionDenied', function(done) {
-      airconsole.getUserMedia({ audio: true }).then(function(result) {
-        expect(result.success).toBe(false);
-        expect(result.errorType).toBe('AirConsole.temporary');
+    it('Should reject AirConsole.USERMEDIA_ERROR.permissionDenied on userMediaPermissionDenied', function(done) {
+      airconsole.getUserMedia({ audio: true }).catch(function(error) {
+        expect(error.name).toBe('AirConsole.UserMediaError');
+        expect(error.message).toBe('PermissionDenied');
         done();
       });
       dispatchCustomMessageEvent({
         action: 'event', type: 'userMediaPermissionDenied',
-        data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.temporary }
       });
     });
 
-    it('Should resolve {success:false, errorType:AirConsole.permanent} on userMediaPermissionDenied with permanent', function(done) {
-      airconsole.getUserMedia({ audio: true }).then(function(result) {
-        expect(result.success).toBe(false);
-        expect(result.errorType).toBe('AirConsole.permanent');
-        done();
-      });
-      dispatchCustomMessageEvent({
-        action: 'event', type: 'userMediaPermissionDenied',
-        data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.permanent }
-      });
-    });
-
-    it('Should resolve {success:false, errorType:AirConsole.outdated} on userMediaPermissionDenied with outdated', function(done) {
-      airconsole.getUserMedia({ audio: true }).then(function(result) {
-        expect(result.success).toBe(false);
-        expect(result.errorType).toBe('AirConsole.outdated');
-        done();
-      });
-      dispatchCustomMessageEvent({
-        action: 'event', type: 'userMediaPermissionDenied',
-        data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.outdated }
-      });
-    });
-
-    it('Should resolve {success:true, stream} on userMediaPermissionGranted when browser succeeds', function(done) {
+    it('Should resolve stream on userMediaPermissionGranted when browser succeeds', function(done) {
       const fakeStream = makeFakeStream();
       spyOn(navigator.mediaDevices, 'getUserMedia').and.returnValue(Promise.resolve(fakeStream));
-      airconsole.getUserMedia({ audio: true }).then(function(result) {
-        expect(result.success).toBe(true);
-        expect(result.stream).toBe(fakeStream);
+      airconsole.getUserMedia({ audio: true }).then(function(stream) {
+        expect(stream).toBe(fakeStream);
         done();
       });
       dispatchCustomMessageEvent({ action: 'event', type: 'userMediaPermissionGranted' });
     });
 
-    it('Should resolve {success:false, error} on userMediaPermissionGranted when browser rejects', function(done) {
+    it('Should reject on userMediaPermissionGranted when browser rejects', function(done) {
       const testError = new Error('getUserMedia failed: Permission denied');
       spyOn(navigator.mediaDevices, 'getUserMedia').and.callFake(function() { return Promise.reject(testError); });
-      airconsole.getUserMedia({ audio: true }).then(function(result) {
-        expect(result.success).toBe(false);
-        expect(result.error).toBe(testError);
+      airconsole.getUserMedia({ audio: true }).catch(function(error) {
+        expect(error).toBe(testError);
         done();
       });
       dispatchCustomMessageEvent({ action: 'event', type: 'userMediaPermissionGranted' });
     });
 
-    it('Should resolve {success:true, stream} on promptUserMediaPermission when browser succeeds', function(done) {
+    it('Should resolve stream on promptUserMediaPermission when browser succeeds', function(done) {
       const fakeStream = makeFakeStream();
       spyOn(navigator.mediaDevices, 'getUserMedia').and.returnValue(Promise.resolve(fakeStream));
-      airconsole.getUserMedia({ audio: true }).then(function(result) {
-        expect(result.success).toBe(true);
-        expect(result.stream).toBe(fakeStream);
+      airconsole.getUserMedia({ audio: true }).then(function(stream) {
+        expect(stream).toEqual(fakeStream);
         done();
       });
       dispatchCustomMessageEvent({ action: 'event', type: 'promptUserMediaPermission' });
@@ -217,12 +170,23 @@ function testUserMediaPermissions() {
       dispatchCustomMessageEvent({ action: 'event', type: 'userMediaPermissionGranted' });
     });
 
+    it('Should clear media_permission_pending_ when userMediaPermissionDenied is received', function (done) {
+      airconsole.getUserMedia({ audio: true }).catch(function () {
+        expect(airconsole.media_permission_pending_).toBe(false);
+        done();
+      });
+      dispatchCustomMessageEvent({
+        action: 'event',
+        type: 'userMediaPermissionDenied',
+      });
+    });
+
     // Group 3: Timeout
 
-    it('Should resolve {success:false, error:{message:AirConsole.USERMEDIA_ERROR.timeout}} after 30000ms', function(done) {
-      airconsole.getUserMedia({ audio: true }).then(function(result) {
-        expect(result.success).toBe(false);
-        expect(result.error.message).toBe(AirConsole.USERMEDIA_ERROR.timeout);
+    it('Should reject with AirConsole.USERMEDIA_ERROR.timeout after 30000ms', function(done) {
+      airconsole.getUserMedia({ audio: true }).catch(function(error) {
+        expect(error.name).toBe("AirConsole.UserMediaError");
+        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.timeout);
         done();
       });
       jasmine.clock().tick(30001);
@@ -235,24 +199,12 @@ function testUserMediaPermissions() {
     beforeEach(function () {
       initAirConsoleAsController();
       // Spy on sendEvent_ and simulate the platform echo for denial events.
-      // In the new flow the controller caches the error locally, notifies the platform
-      // (with userPromptDuration only), and the platform echoes back a userMediaPermissionDenied
-      // event containing errorType. The implementation then rejects with the cached error.
       spyOn(airconsole, 'sendEvent_').and.callFake(function (eventType, eventData) {
-        if (eventType === 'userMediaPermissionDenied' && eventData && eventData.userPromptDuration !== undefined) {
-          dispatchCustomMessageEvent({
-            action: 'event',
-            type: 'userMediaPermissionDenied',
-            data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.temporary },
-          });
-        } else {
-          // Pipe the event back
-          dispatchCustomMessageEvent({
-            action: 'event',
-            type: eventType,
-            data: eventData
-          });
-        }
+        dispatchCustomMessageEvent({
+          action: 'event',
+          type: eventType,
+          data: eventData
+        });
       });
     });
 
@@ -268,12 +220,10 @@ function testUserMediaPermissions() {
       spyOn(navigator.mediaDevices, 'getUserMedia').and.returnValue(Promise.resolve(stream));
     }
 
-    // Dispatches a userMediaPermissionDenied event with an optional errorType
-    // (defaults to AirConsole.temporary, matching the most common test scenario).
-    function dispatchDenied(errorType) {
+    // Dispatches a userMediaPermissionDenied event
+    function dispatchDenied() {
       dispatchCustomMessageEvent({
         action: 'event', type: 'userMediaPermissionDenied',
-        data: { errorType: errorType || AirConsole.USERMEDIA_ERROR_TYPE.temporary }
       });
     }
 
@@ -284,13 +234,8 @@ function testUserMediaPermissions() {
         let resolutionCount = 0;
         airconsole
           .getUserMedia({ audio: true })
-          .then(function (result) {
-            resolutionCount++;
-            expect(result.success).toBe(false);
-            expect(result.errorType).toBe('AirConsole.temporary');
-          })
           .catch(function () {
-            fail('Should not reject after resolution');
+            resolutionCount++;
           })
           .then(function () {
             // Second event — no-op since promise already settled
@@ -305,7 +250,6 @@ function testUserMediaPermissions() {
         const domException = new DOMException('DOM Abort Test', 'AbortError');
         spyGetUserMediaReject(domException);
         airconsole.getUserMedia({ audio: true })
-          .then(it =>  console.info(it))
           .catch(function(error) {
             expect(error).toBe(domException);
             expect(error).toBeInstanceOf(DOMException);
@@ -321,11 +265,9 @@ function testUserMediaPermissions() {
 
     // --- Group 5: promptUserMediaPermission + NotAllowedError ---
     // Platform sends 'promptUserMediaPermission'; browser getUserMedia fails with NotAllowedError.
-    // Implementation caches the error, fires sendEvent_('userMediaPermissionDenied') with
-    // userPromptDuration, then when platform echoes back errorType, rejects with cached error.
-
+    // Implementation caches the error, fires sendEvent_('userMediaPermissionDenied').
     describe('promptUserMediaPermission NotAllowedError rejection flow', function () {
-      it('Should fire sendEvent_(userMediaPermissionDenied) with userPromptDuration', function (done) {
+      it('Should fire sendEvent_(userMediaPermissionDenied)', function (done) {
         const domException = makeNotAllowedError();
         spyGetUserMediaReject(domException);
         airconsole.getUserMedia({ audio: true }).catch(function () {
@@ -366,7 +308,6 @@ function testUserMediaPermissions() {
       it('Should call sendEvent_(userMediaPermissionGranted) on userMediaPermissionGranted event', function (done) {
         spyGetUserMediaResolve(makeFakeStream());
         airconsole.getUserMedia({ audio: true }).then(function (result) {
-          expect(result.success).toBe(true);
           expect(airconsole.sendEvent_).toHaveBeenCalledWith(
             'userMediaPermissionGranted',
             { constraints: { audio: true } },
@@ -382,7 +323,6 @@ function testUserMediaPermissions() {
       it('Should call sendEvent_(userMediaPermissionGranted) on promptUserMediaPermission event', function (done) {
         spyGetUserMediaResolve(makeFakeStream());
         airconsole.getUserMedia({ audio: true }).then(function (result) {
-          expect(result.success).toBe(true);
           expect(airconsole.sendEvent_).toHaveBeenCalledWith(
             'userMediaPermissionGranted',
             { constraints: { audio: true } },
@@ -394,7 +334,7 @@ function testUserMediaPermissions() {
 
       it('Should NOT call sendEvent_(userMediaPermissionGranted) when browser getUserMedia rejects', function (done) {
         spyGetUserMediaReject(new DOMException('Permission denied', 'NotAllowedError'));
-        airconsole.getUserMedia({ audio: true }).then(function () {
+        airconsole.getUserMedia({ audio: true }).catch(function () {
           const grantedCalls = airconsole.sendEvent_.calls
             .all()
             .filter(function (call) {
@@ -441,36 +381,16 @@ function testUserMediaPermissions() {
       );
     });
 
-    it('Should call onUserMediaAccessDenied(device_id, temporary) when granted=false with temporary errorType', function () {
+    it('Should call onUserMediaAccessDenied(device_id, temporary) when granted=false', function () {
       spyOn(airconsole, 'onUserMediaAccessDenied');
+      const constraints = { audio: true };
+      airconsole.media_permission_constraints_ = constraints;
       broadcastPermissionUpdate({
-        granted: false,
-        errorType: AirConsole.USERMEDIA_ERROR_TYPE.temporary,
+        granted: false
       });
       expect(airconsole.onUserMediaAccessDenied).toHaveBeenCalledWith(
         DEVICE_ID,
-        AirConsole.USERMEDIA_ERROR_TYPE.temporary,
-      );
-    });
-
-    it('Should call onUserMediaAccessDenied(device_id, permanent) when granted=false with permanent errorType', function () {
-      spyOn(airconsole, 'onUserMediaAccessDenied');
-      broadcastPermissionUpdate({
-        granted: false,
-        errorType: AirConsole.USERMEDIA_ERROR_TYPE.permanent,
-      });
-      expect(airconsole.onUserMediaAccessDenied).toHaveBeenCalledWith(
-        DEVICE_ID,
-        AirConsole.USERMEDIA_ERROR_TYPE.permanent,
-      );
-    });
-
-    it('Should default errorType to temporary when granted=false but no errorType field', function () {
-      spyOn(airconsole, 'onUserMediaAccessDenied');
-      broadcastPermissionUpdate({ granted: false });
-      expect(airconsole.onUserMediaAccessDenied).toHaveBeenCalledWith(
-        DEVICE_ID,
-        AirConsole.USERMEDIA_ERROR_TYPE.temporary,
+        jasmine.objectContaining(constraints)
       );
     });
 
@@ -530,28 +450,18 @@ function testUserMediaPermissions() {
   });
 
   // --- Groups 8, 10, 11: shared boilerplate (part 2, after Groups 7 and 9) ---
-
   describe('media permission flows', function () {
     beforeEach(function () {
       initAirConsoleAsController();
       // Simulate the platform echo for denial events.
-      // In the new flow, the controller caches the error locally and sends userPromptDuration
-      // to the platform. Platform echoes back with errorType.
+      // In the new flow, the controller caches the error locally. Platform echoes back with errorType.
       spyOn(airconsole, 'sendEvent_').and.callFake(function (eventType, eventData) {
-        if (eventType === 'userMediaPermissionDenied' && eventData && eventData.userPromptDuration !== undefined) {
-          dispatchCustomMessageEvent({
-            action: 'event',
-            type: 'userMediaPermissionDenied',
-            data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.temporary },
-          });
-        } else {
-          // Pipe the event back
-          dispatchCustomMessageEvent({
-            action: 'event',
-            type: eventType,
-            data: eventData
-          });
-        }
+        // Pipe the event back
+        dispatchCustomMessageEvent({
+          action: 'event',
+          type: eventType,
+          data: eventData
+        });
       });
     });
 
@@ -563,13 +473,10 @@ function testUserMediaPermissions() {
       });
     }
 
-    function dispatchDenied(errorType) {
+    function dispatchDenied() {
       dispatchCustomMessageEvent({
         action: 'event',
         type: 'userMediaPermissionDenied',
-        data: {
-          errorType: errorType || AirConsole.USERMEDIA_ERROR_TYPE.temporary,
-        },
       });
     }
 
@@ -590,60 +497,11 @@ function testUserMediaPermissions() {
         promptUserMediaPermission();
       });
     });
-
-    // --- Group 9b: platform-only userMediaPermissionDenied with errorType ---
-
-    describe('platform-initiated userMediaPermissionDenied with errorType', function () {
-      it('Should resolve {success:false, errorType} when platform sends errorType without cached error', function (done) {
-        airconsole.getUserMedia({ audio: true }).then(function (result) {
-          expect(result.success).toBe(false);
-          expect(result.errorType).toBe(AirConsole.USERMEDIA_ERROR_TYPE.permanent);
-          done();
-        });
-        dispatchCustomMessageEvent({
-          action: 'event',
-          type: 'userMediaPermissionDenied',
-          data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.permanent },
-        });
-      });
-
-      it('Should clear media_permission_pending_ when platform sends errorType', function (done) {
-        airconsole.getUserMedia({ audio: true }).then(function () {
-          expect(airconsole.media_permission_pending_).toBe(false);
-          done();
-        });
-        dispatchCustomMessageEvent({
-          action: 'event',
-          type: 'userMediaPermissionDenied',
-          data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.permanent },
-        });
-      });
-    });
-
-    // --- Group 10: userMediaPermissionDenied with missing data field ---
-
-    describe('userMediaPermissionDenied with missing data', function () {
-      it('Should default errorType to temporary when data field is absent', function (done) {
-        airconsole.getUserMedia({ audio: true }).then(function (result) {
-          expect(result.success).toBe(false);
-          expect(result.errorType).toBe(
-            AirConsole.USERMEDIA_ERROR_TYPE.temporary,
-          );
-          done();
-        });
-        dispatchCustomMessageEvent({
-          action: 'event',
-          type: 'userMediaPermissionDenied',
-        });
-      });
-    });
-
     // --- Group 11: Re-entry after settlement ---
 
     describe('post-settlement re-entry', function () {
       it('Should allow a subsequent getUserMedia call after successful resolution', function (done) {
-        airconsole.getUserMedia({ audio: true }).then(function (result) {
-          expect(result.success).toBe(false);
+        airconsole.getUserMedia({ audio: true }).catch(function () {
           // Second call should start a new request (confirmed by sendEvent_ being called again)
           airconsole.sendEvent_.calls.reset();
           airconsole.getUserMedia({ audio: true });

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -26,7 +26,16 @@ function testUserMediaPermissions() {
   }
 
   function makeFakeStream() {
-    return { getAudioTracks: function () { return [{}]; } };
+    return {
+      getAudioTracks: function() {
+        return [{}];
+      }, getTracks: function() {
+        return [{
+          stop: () => {
+          }
+        }];
+      },
+    };
   }
 
   function makeNotAllowedError() {
@@ -35,8 +44,7 @@ function testUserMediaPermissions() {
   }
 
   function makeNotFoundError() {
-    const err = new Error('Device not found');
-    err.name = 'NotFoundError';
+    const err = new DOMException('Device not found', 'NotFoundError');
     return err;
   }
 
@@ -237,6 +245,13 @@ function testUserMediaPermissions() {
             type: 'userMediaPermissionDenied',
             data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.temporary },
           });
+        } else {
+          // Pipe the event back
+          dispatchCustomMessageEvent({
+            action: 'event',
+            type: eventType,
+            data: eventData
+          });
         }
       });
     });
@@ -289,15 +304,17 @@ function testUserMediaPermissions() {
       it('Should reject with a DOMException when browser getUserMedia is aborted', function (done) {
         const domException = new DOMException('DOM Abort Test', 'AbortError');
         spyGetUserMediaReject(domException);
-        airconsole.getUserMedia({ audio: true }).catch(function (error) {
-          expect(error).toBe(domException);
-          expect(error).toBeInstanceOf(DOMException);
-          expect(airconsole.sendEvent_).toHaveBeenCalledWith(
-            'userMediaPermissionDenied',
-            jasmine.objectContaining({ userPromptDuration: jasmine.any(Number) }),
-          );
-          done();
-        });
+        airconsole.getUserMedia({ audio: true })
+          .then(it =>  console.info(it))
+          .catch(function(error) {
+            expect(error).toBe(domException);
+            expect(error).toBeInstanceOf(DOMException);
+            expect(airconsole.sendEvent_).toHaveBeenCalledWith(
+              'userMediaPermissionDenied',
+              jasmine.objectContaining({ errorType: domException.name })
+            );
+            done();
+          });
         promptUserMediaPermission();
       });
     });
@@ -309,13 +326,12 @@ function testUserMediaPermissions() {
 
     describe('promptUserMediaPermission NotAllowedError rejection flow', function () {
       it('Should fire sendEvent_(userMediaPermissionDenied) with userPromptDuration', function (done) {
-        spyGetUserMediaReject(makeNotAllowedError());
+        const domException = makeNotAllowedError();
+        spyGetUserMediaReject(domException);
         airconsole.getUserMedia({ audio: true }).catch(function () {
           expect(airconsole.sendEvent_).toHaveBeenCalledWith(
             'userMediaPermissionDenied',
-            jasmine.objectContaining({
-              userPromptDuration: jasmine.any(Number),
-            }),
+              jasmine.objectContaining({ errorType: domException.name })
           );
           done();
         });
@@ -377,7 +393,7 @@ function testUserMediaPermissions() {
       });
 
       it('Should NOT call sendEvent_(userMediaPermissionGranted) when browser getUserMedia rejects', function (done) {
-        spyGetUserMediaReject(new Error('Permission denied'));
+        spyGetUserMediaReject(new DOMException('Permission denied', 'NotAllowedError'));
         airconsole.getUserMedia({ audio: true }).then(function () {
           const grantedCalls = airconsole.sendEvent_.calls
             .all()
@@ -527,6 +543,13 @@ function testUserMediaPermissions() {
             action: 'event',
             type: 'userMediaPermissionDenied',
             data: { errorType: AirConsole.USERMEDIA_ERROR_TYPE.temporary },
+          });
+        } else {
+          // Pipe the event back
+          dispatchCustomMessageEvent({
+            action: 'event',
+            type: eventType,
+            data: eventData
           });
         }
       });

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -117,6 +117,14 @@ function testUserMediaPermissions() {
       });
     });
 
+    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints with constraint { audio: false }', function(done) {
+      airconsole.getUserMedia({ audio: false }).catch(function(error) {
+        expect(error.name).toBe("AirConsole.UserMediaError");
+        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+        done();
+      });
+    });
+
     it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints with constraint { video: { width: 1280, height: 720 } }', function(done) {
       airconsole.getUserMedia({ video: { width: 1280, height: 720 } }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -101,7 +101,31 @@ function testUserMediaPermissions() {
       });
     });
 
-    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints when constraints have no audio or video property', function(done) {
+    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints with constraint { audio: true, video: true }', function(done) {
+      airconsole.getUserMedia({ video: true }).catch(function(error) {
+        expect(error.name).toBe("AirConsole.UserMediaError");
+        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+        done();
+      });
+    });
+
+    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints with constraint { video: true }', function(done) {
+      airconsole.getUserMedia({ video: true }).catch(function(error) {
+        expect(error.name).toBe("AirConsole.UserMediaError");
+        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+        done();
+      });
+    });
+
+    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints with constraint { video: { width: 1280, height: 720 } }', function(done) {
+      airconsole.getUserMedia({ video: { width: 1280, height: 720 } }).catch(function(error) {
+        expect(error.name).toBe("AirConsole.UserMediaError");
+        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);
+        done();
+      });
+    });
+
+    it('Should reject with AirConsole.USERMEDIA_ERROR.invalidConstraints when constraints have no audio property', function(done) {
       airconsole.getUserMedia({ foo: true }).catch(function(error) {
         expect(error.name).toBe("AirConsole.UserMediaError");
         expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.invalidConstraints);

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -372,25 +372,21 @@ function testUserMediaPermissions() {
       });
     }
 
-    it('Should call onUserMediaAccessGranted(device_id, constraints) when granted=true', function () {
+    it('Should call onUserMediaAccessGranted(device_id) when granted=true', function () {
       spyOn(airconsole, 'onUserMediaAccessGranted');
       broadcastPermissionUpdate({ granted: true });
       expect(airconsole.onUserMediaAccessGranted).toHaveBeenCalledWith(
         DEVICE_ID,
-        undefined,
       );
     });
 
-    it('Should call onUserMediaAccessDenied(device_id, temporary) when granted=false', function () {
+    it('Should call onUserMediaAccessDenied(device_id) when granted=false', function () {
       spyOn(airconsole, 'onUserMediaAccessDenied');
-      const constraints = { audio: true };
-      airconsole.mediaPermissionConstraints_ = constraints;
       broadcastPermissionUpdate({
         granted: false
       });
       expect(airconsole.onUserMediaAccessDenied).toHaveBeenCalledWith(
         DEVICE_ID,
-        jasmine.objectContaining(constraints)
       );
     });
 

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -644,8 +644,8 @@ function testUserMediaPermissions() {
 
       // Trigger promptUserMediaPermission to start the browser flow
       dispatchCustomMessageEvent({ action: 'event', type: 'promptUserMediaPermission' });
-      // Fire the 30s timeout
-      jasmine.clock().tick(30001);
+      // Fire the 45s timeout
+      jasmine.clock().tick(45001);
     });
 
     it('Should stop orphaned stream tracks when browser succeeds after timeout', function (done) {
@@ -693,7 +693,7 @@ function testUserMediaPermissions() {
       });
 
       dispatchCustomMessageEvent({ action: 'event', type: 'promptUserMediaPermission' });
-      jasmine.clock().tick(30001);
+      jasmine.clock().tick(45001);
     });
   });
 

--- a/tests/spec/methods/spec-usermedia-permissions.js
+++ b/tests/spec/methods/spec-usermedia-permissions.js
@@ -566,11 +566,11 @@ function testUserMediaPermissions() {
         new Promise(function () {}),
       );
       spyOn(airconsole, 'sendEvent_');
-      airconsole.getUserMedia({ audio: true });
+      airconsole.getUserMedia({ audio: true }).catch(function () {});
       expect(airconsole.mediaPermissionTimeout_).toBeDefined();
 
       airconsole.destroy();
-      expect(airconsole.mediaPermissionTimeout_).toBeNull();
+      expect(airconsole.mediaPermissionTimeout_).toBeUndefined();
       jasmine.clock().uninstall();
     });
 
@@ -579,5 +579,194 @@ function testUserMediaPermissions() {
         airconsole.destroy();
       }).not.toThrow();
     });
+
+    it('Should reject pending getUserMedia Promise on destroy', function (done) {
+      jasmine.clock().install();
+      spyOn(navigator.mediaDevices, 'getUserMedia').and.returnValue(
+        new Promise(function () {}),
+      );
+      spyOn(airconsole, 'sendEvent_');
+      airconsole.getUserMedia({ audio: true }).catch(function (error) {
+        expect(error.name).toBe('AirConsole.UserMediaError');
+        expect(error.message).toBe(AirConsole.USERMEDIA_ERROR.timeout);
+        done();
+      });
+      airconsole.destroy();
+      jasmine.clock().uninstall();
+    });
+
+    it('Should clear mediaPermissionPending_ when destroy rejects pending Promise', function (done) {
+      jasmine.clock().install();
+      spyOn(navigator.mediaDevices, 'getUserMedia').and.returnValue(
+        new Promise(function () {}),
+      );
+      spyOn(airconsole, 'sendEvent_');
+      airconsole.getUserMedia({ audio: true }).catch(function () {
+        expect(airconsole.mediaPermissionPending_).toBe(false);
+        done();
+      });
+      airconsole.destroy();
+      jasmine.clock().uninstall();
+    });
   }); // end 'destroy'
+
+  // --- Group 13: Race condition and edge case coverage ---
+
+  describe('race condition coverage', function () {
+    beforeEach(function () {
+      jasmine.clock().install();
+      initAirConsoleAsController();
+      spyOn(airconsole, 'sendEvent_');
+    });
+
+    afterEach(function () {
+      jasmine.clock().uninstall();
+      teardown();
+    });
+
+    it('Should not send userMediaPermissionDenied when browser failure arrives after timeout', function (done) {
+      var browserReject;
+      spyOn(navigator.mediaDevices, 'getUserMedia').and.callFake(function () {
+        return new Promise(function (resolve, reject) {
+          browserReject = reject;
+        });
+      });
+
+      airconsole.getUserMedia({ audio: true }).catch(function () {
+        // Timeout has fired. Now simulate the late browser failure.
+        airconsole.sendEvent_.calls.reset();
+        browserReject(new DOMException('Late denial', 'NotAllowedError'));
+
+        // Give microtasks a chance to run
+        setTimeout(function () {
+          expect(airconsole.sendEvent_).not.toHaveBeenCalledWith(
+            'userMediaPermissionDenied',
+            jasmine.anything(),
+          );
+          done();
+        }, 0);
+        jasmine.clock().tick(1);
+      });
+
+      // Trigger promptUserMediaPermission to start the browser flow
+      dispatchCustomMessageEvent({ action: 'event', type: 'promptUserMediaPermission' });
+      // Fire the 30s timeout
+      jasmine.clock().tick(30001);
+    });
+
+    it('Should stop orphaned stream tracks when browser succeeds after timeout', function (done) {
+      var stopSpy = jasmine.createSpy('stop');
+      var fakeStream = {
+        getAudioTracks: function () { return [{}]; },
+        getTracks: function () { return [{ stop: stopSpy }]; },
+      };
+      spyOn(navigator.mediaDevices, 'getUserMedia').and.callFake(function () {
+        // Simulate: timeout fires before browser resolves.
+        // Setting mediaPermissionPending_ to false models what cleanUpMediaPermission_ does.
+        airconsole.mediaPermissionPending_ = false;
+        return Promise.resolve(fakeStream);
+      });
+
+      airconsole.getUserMedia({ audio: true }).catch(function () {
+        // Give microtasks time to process the browser success callback.
+        setTimeout(function () {
+          expect(stopSpy).toHaveBeenCalled();
+          done();
+        }, 0);
+        jasmine.clock().tick(1);
+      });
+
+      dispatchCustomMessageEvent({ action: 'event', type: 'promptUserMediaPermission' });
+      jasmine.clock().tick(30001);
+    });
+
+    it('Should not set cachedMediaError_ when browser failure arrives after timeout', function (done) {
+      var browserReject;
+      spyOn(navigator.mediaDevices, 'getUserMedia').and.callFake(function () {
+        return new Promise(function (resolve, reject) {
+          browserReject = reject;
+        });
+      });
+
+      airconsole.getUserMedia({ audio: true }).catch(function () {
+        browserReject(new DOMException('Late error', 'NotFoundError'));
+
+        setTimeout(function () {
+          expect(airconsole.cachedMediaError_).toBeFalsy();
+          done();
+        }, 0);
+        jasmine.clock().tick(1);
+      });
+
+      dispatchCustomMessageEvent({ action: 'event', type: 'promptUserMediaPermission' });
+      jasmine.clock().tick(30001);
+    });
+  });
+
+  // --- Group 14: Stale message guard and type verification ---
+
+  describe('stale message guard and error types', function () {
+    beforeEach(function () {
+      initAirConsoleAsController();
+      spyOn(airconsole, 'sendEvent_');
+    });
+
+    afterEach(teardown);
+
+    it('Should ignore userMediaPermissionGranted after flow is already settled', function (done) {
+      spyOn(navigator.mediaDevices, 'getUserMedia');
+      airconsole.getUserMedia({ audio: true }).catch(function () {
+        // Flow is settled (denied). Now dispatch a stale granted event.
+        dispatchCustomMessageEvent({ action: 'event', type: 'userMediaPermissionGranted' });
+
+        setTimeout(function () {
+          expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
+          done();
+        }, 0);
+      });
+      dispatchCustomMessageEvent({ action: 'event', type: 'userMediaPermissionDenied' });
+    });
+
+    it('Should ignore userMediaPermissionDenied after flow is already settled', function (done) {
+      var catchCount = 0;
+      var fakeStream = makeFakeStream();
+      spyOn(navigator.mediaDevices, 'getUserMedia').and.returnValue(Promise.resolve(fakeStream));
+      airconsole.getUserMedia({ audio: true })
+        .then(function () {
+          // Flow is settled (granted). Now dispatch a stale denied event.
+          dispatchCustomMessageEvent({ action: 'event', type: 'userMediaPermissionDenied' });
+        })
+        .catch(function () {
+          catchCount++;
+        });
+
+      dispatchCustomMessageEvent({ action: 'event', type: 'userMediaPermissionGranted' });
+
+      setTimeout(function () {
+        expect(catchCount).toBe(0);
+        done();
+      }, 50);
+    });
+
+    it('Should produce errors that are instanceof Error', function (done) {
+      airconsole.device_id = AirConsole.SCREEN;
+      airconsole.getUserMedia({ audio: true }).catch(function (error) {
+        expect(error instanceof Error).toBe(true);
+        expect(error.name).toBe('AirConsole.UserMediaError');
+        done();
+      });
+    });
+
+    it('Should forward complex audio constraints to browser getUserMedia', function (done) {
+      var complexConstraints = { audio: { echoCancellation: true, noiseSuppression: false } };
+      spyOn(navigator.mediaDevices, 'getUserMedia').and.returnValue(
+        Promise.resolve(makeFakeStream()),
+      );
+      airconsole.getUserMedia(complexConstraints).then(function () {
+        expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith(complexConstraints);
+        done();
+      });
+      dispatchCustomMessageEvent({ action: 'event', type: 'userMediaPermissionGranted' });
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Games previously had to inspect a `{success, stream?, reason?, error?}` envelope and branch on multiple fields to handle `getUserMedia` outcomes. The Promise now resolves with a `MediaStream` on success and rejects with a typed `Error` on failure, matching the semantics of the browser's native `navigator.mediaDevices.getUserMedia`.

## What changed for game developers

**Standard Promise semantics.** Use `.then(stream => ...)` for success and `.catch(error => ...)` for failure. No more `if (result.success)` inspection.

```js
airconsole.getUserMedia({ audio: true })
  .then(function(stream) { /* use the stream */ })
  .catch(function(error) {
    if (error.name === 'AirConsole.UserMediaError') {
      // Platform error: timeout, permission denied, invalid constraints, etc.
    } else {
      // Native browser DOMException (NotAllowedError, NotFoundError, AbortError)
    }
  });
```

**Typed errors with `instanceof` support.** Browser `DOMException` objects survive the platform roundtrip intact, so `error instanceof DOMException` and `error.name === 'NotAllowedError'` work as expected. AirConsole-specific failures use `AirConsoleUserMediaError` (extends `Error`) with messages from `AirConsole.USERMEDIA_ERROR`.

**Explicit audio-only constraint validation.** Video constraints are now explicitly rejected with `USERMEDIA_ERROR.invalidConstraints` rather than silently ignored. The `audio` property is required.

**Simplified broadcast callbacks.** `onUserMediaAccessGranted(device_id)` and `onUserMediaAccessDenied(device_id)` no longer carry a second parameter. The requesting device gets full error details through its Promise; other devices only need to know the outcome.

**Removed `MEDIA_PERMISSION_DENIED` enum.** The `temporary`/`permanent` distinction is replaced by `USERMEDIA_ERROR.permissionDenied` for platform denials and the original `DOMException` for browser denials, giving games richer error information without a custom enum.

## Error types

| Error | Source | When |
|---|---|---|
| `AirConsoleUserMediaError("NotSupportedOnScreen")` | AirConsole | Called from screen device |
| `AirConsoleUserMediaError("NotReady")` | AirConsole | SDK not initialized |
| `AirConsoleUserMediaError("AlreadyPending")` | AirConsole | Duplicate concurrent request |
| `AirConsoleUserMediaError("InvalidConstraints")` | AirConsole | Missing audio, has video, or null |
| `AirConsoleUserMediaError("Timeout")` | AirConsole | No platform response within 30s |
| `AirConsoleUserMediaError("PermissionDenied")` | AirConsole | Platform denies without browser prompt |
| `DOMException("NotAllowedError")` | Browser | User denied the permission dialog |
| `DOMException("NotFoundError")` | Browser | No microphone hardware available |

## Internal mechanism

Browser prompt failures use a cache-and-echo pattern: the `DOMException` is stored in `cachedMediaError_` before notifying the platform with only `{ errorType: error.name }`. When the platform echoes back, the cached object is passed to `reject()`, preserving full `DOMException` fidelity across the platform roundtrip without serializing non-transferable objects.